### PR TITLE
DockerDance v0.3.0 — robustness, safety and UX overhaul

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -11,6 +11,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: ShellCheck
-        run: shellcheck docker_volumes/manage.sh
+        run: shellcheck docker_volumes/manage.sh contrib/dockerdance-completion.bash
       - name: POSIX syntax check (dash)
         run: sh -n docker_volumes/manage.sh

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,0 +1,16 @@
+name: Lint
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  shellcheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: ShellCheck
+        run: shellcheck docker_volumes/manage.sh
+      - name: POSIX syntax check (dash)
+        run: sh -n docker_volumes/manage.sh

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+# Local configuration - may contain a webhook URL or host-specific paths
+docker_volumes/manage.conf
+
+# Backup archives and restore leftovers
+docker_volumes/backup/*.tar.bz2
+docker_volumes/*.pre-restore.*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,10 @@ All notable changes to DockerDance are documented here. The format follows
 [Semantic Versioning](https://semver.org/). `./manage.sh update-self` updates to
 the latest tagged release.
 
-## [Unreleased]
+## [0.3.0] - 2026-07-13
 
-The changes below are on the way to the next release. Until they're tagged,
-`update-self` will not offer them.
+The first release since v0.1.0 - a substantial robustness, safety and UX
+overhaul. `./manage.sh update-self` will offer this to anyone on v0.1.0.
 
 ### Added
 - **`status` dashboard.** One line per app - a coloured up/stopped dot,
@@ -39,7 +39,7 @@ The changes below are on the way to the next release. Until they're tagged,
   back in place: stops the app, moves the current data aside to
   `<app>.pre-restore.<timestamp>` (nothing is deleted), extracts, and starts
   again. Asks for confirmation, rolls back if extraction fails, and reads both
-  the new relative-path archives and pre-v0.2.0 absolute-path ones.
+  the new relative-path archives and older v0.1.0-era absolute-path ones.
 - **`system-update` command.** Detects the host package manager — apt-get, dnf,
   yum, pacman, zypper, apk or brew — and runs the right non-interactive update,
   with per-manager root handling. `apt` remains as an alias.
@@ -102,5 +102,5 @@ The changes below are on the way to the next release. Until they're tagged,
 - Initial release: bulk `start` / `stop` / `restart` / `update` / `backup` of
   docker-compose apps laid out in per-app folders.
 
-[Unreleased]: https://github.com/AdamXweb/DockerDance/compare/v0.1.0...HEAD
+[0.3.0]: https://github.com/AdamXweb/DockerDance/compare/v0.1.0...v0.3.0
 [0.1.0]: https://github.com/AdamXweb/DockerDance/releases/tag/v0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,25 @@ The changes below are on the way to the next release. Until they're tagged,
 `update-self` will not offer them.
 
 ### Added
+- **`status` dashboard.** One line per app - a coloured up/stopped dot,
+  container state, image and health - built read-only from `compose ps -q`
+  plus `docker inspect`.
+- **`doctor` command.** Read-only environment/config check: docker daemon,
+  compose flavour, curl/wget/fzf, the system-update package manager, tar
+  safety, `DOCKER_VOLUMES` writability, `manage.conf`, stale lock, effective
+  settings and discovered apps.
+- **Health-aware start.** After `up -d`, `start`/`restart`/`update`/`backup`/
+  `restore` wait for containers to become healthy (or just running, with no
+  healthcheck) before reporting done. Tunable with `HEALTH_TIMEOUT` (0 skips).
+- **Parallel image pulls.** `update` and `backup` pull all target apps'
+  images at once, up to `PARALLEL_PULLS` (default 3); a failed pull leaves
+  that app on its current image and is skipped rather than aborting the run.
+- **`--dry-run`** previews any command without touching anything, **`-y`/`--yes`**
+  skips confirmations (and lets `restore` run non-interactively), and **update**
+  now confirms before recreating containers on a terminal. **`--no-color`** flag.
+- **Multi-app selection in the menu.** fzf `TAB` multi-select, or a
+  space/comma list in the numbered fallback.
+- **zsh and fish completions** alongside the bash one.
 - **Zero-config app discovery.** `Apps="auto"` (the new default) manages every
   folder that contains a compose file (`docker-compose.yml`/`.yaml` or
   `compose.yml`/`.yaml`, or one folder deeper), in alphabetical order. Drop
@@ -53,6 +72,16 @@ The changes below are on the way to the next release. Until they're tagged,
   (portable restores); a second backup in the same day no longer overwrites the
   first.
 - Multi-app runs end with a per-app summary table (app / action / seconds).
+
+### Security
+- **`restore` treats archives as untrusted.** Extraction happens in an
+  isolated staging area (never `tar -C /`); members with `..` traversal or
+  absolute paths are refused; legacy absolute-path archives are declined on
+  busybox tar; and only the app's own folder is promoted into place. A
+  tampered backup can no longer write elsewhere on disk.
+- **Unpredictable temp file.** The step-output log is created with `mktemp`
+  (owner-only, random name) instead of a predictable `/tmp` name, closing a
+  symlink pre-creation angle when running as root.
 
 ### Fixed
 - **Graceful shutdown before backup.** `docker compose kill` (SIGKILL) is

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,8 +30,11 @@ overhaul. `./manage.sh update-self` will offer this to anyone on v0.1.0.
 - **`--dry-run`** previews any command without touching anything, **`-y`/`--yes`**
   skips confirmations (and lets `restore` run non-interactively), and **update**
   now confirms before recreating containers on a terminal. **`--no-color`** flag.
-- **Multi-app selection in the menu.** fzf `TAB` multi-select, or a
-  space/comma list in the numbered fallback.
+- **Interactive menu upgrades.** The command list is now fzf-driven when fzf
+  is installed (arrow-key navigation, type-to-filter, Esc to quit/go back) and
+  includes `system-update` and `update-self`; the numbered fallback also
+  accepts a typed command name and a `b` to go back. Multi-app selection via
+  fzf `TAB` or a space/comma list.
 - **zsh and fish completions** alongside the bash one.
 - **Zero-config app discovery.** `Apps="auto"` (the new default) manages every
   folder that contains a compose file (`docker-compose.yml`/`.yaml` or

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ The first release since v0.1.0 - a substantial robustness, safety and UX
 overhaul. `./manage.sh update-self` will offer this to anyone on v0.1.0.
 
 ### Added
+- **Docker install offer.** When Docker isn't installed, commands now point to
+  the official install docs and can fetch and run Docker's `get.docker.com`
+  script for you after you confirm (interactive only, never in cron).
 - **`status` dashboard.** One line per app - a coloured up/stopped dot,
   container state, image and health - built read-only from `compose ps -q`
   plus `docker inspect`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,77 @@
+# Changelog
+
+All notable changes to DockerDance are documented here. The format follows
+[Keep a Changelog](https://keepachangelog.com/), and the project aims to follow
+[Semantic Versioning](https://semver.org/). `./manage.sh update-self` updates to
+the latest tagged release.
+
+## [Unreleased]
+
+The changes below are on the way to the next release. Until they're tagged,
+`update-self` will not offer them.
+
+### Added
+- **Zero-config app discovery.** `Apps="auto"` (the new default) manages every
+  folder that contains a compose file (`docker-compose.yml`/`.yaml` or
+  `compose.yml`/`.yaml`, or one folder deeper), in alphabetical order. Drop
+  `manage.sh` into a `docker_volumes` folder and it just works. The `backup`
+  folder and `*.pre-restore.*` folders are skipped.
+- **`restore` command** (issue #2). Puts the newest backup archive for an app
+  back in place: stops the app, moves the current data aside to
+  `<app>.pre-restore.<timestamp>` (nothing is deleted), extracts, and starts
+  again. Asks for confirmation, rolls back if extraction fails, and reads both
+  the new relative-path archives and pre-v0.2.0 absolute-path ones.
+- **`system-update` command.** Detects the host package manager — apt-get, dnf,
+  yum, pacman, zypper, apk or brew — and runs the right non-interactive update,
+  with per-manager root handling. `apt` remains as an alias.
+- **`update-self` command.** Updates the script to the latest GitHub release:
+  downloads `manage.sh` at the release tag, syntax-checks it, carries your
+  settings over, and swaps it in place.
+- **Interactive menu** when run with no arguments on a terminal: pick a command,
+  then an app (or all). Uses fzf with a live `compose ps` preview when available,
+  otherwise a numbered menu with a running/stopped dot per app.
+- **Per-app targeting** (issue #1): `./manage.sh restart linkace` acts on just
+  the named app(s).
+- **Nested compose folders** (issue #6): if an app's compose file sits one
+  folder deeper, the script follows it automatically when unambiguous.
+- **Webhook notifications** (issue #3) via `NOTIFY_WEBHOOK` on update/backup/
+  restore completion or failure (Slack and Discord payloads).
+- **Colour, spinners, progress counters and run timing** (issue #5), respecting
+  `NO_COLOR` and falling back to plain output without a terminal.
+- **Optional `manage.conf`** for all settings, so configuration survives
+  `update-self`. See `docker_volumes/manage.conf.example`.
+- **`STOP_TIMEOUT`** and **`BACKUP_KEEP`** settings, `--version` flag, a run lock
+  to stop overlapping runs, and a bash completion in `contrib/`.
+- Shellcheck + dash CI workflow.
+
+### Changed
+- `update` and `backup` now **pull images while the app is still running**, then
+  stop and start — downtime shrinks to just the restart window.
+- Stops use `docker compose stop -t $STOP_TIMEOUT` (default 30s) so a busy
+  database isn't SIGKILLed at docker's 10s default.
+- Backups are written `chmod 600` with paths relative to `docker_volumes`
+  (portable restores); a second backup in the same day no longer overwrites the
+  first.
+- Multi-app runs end with a per-app summary table (app / action / seconds).
+
+### Fixed
+- **Graceful shutdown before backup.** `docker compose kill` (SIGKILL) is
+  replaced with `docker compose stop` everywhere, so databases shut down cleanly
+  before their volumes are archived — `kill` risked backing up corrupt state.
+- The Docker "is it installed?" check actually runs now (it was unreachable
+  under `set -e`), and a `docker info` daemon-reachability check was added.
+- Removed a stray `exec "$@"` that ran leftover arguments as a command.
+- POSIX/dash correctness: `==` → `=`, quoted path expansions, backticks →
+  `$(...)`; the `#!/bin/sh` shebang is now honest under dash.
+- The backup target folder is created automatically (`mkdir -p`).
+- `logs` no longer blocks forever on the first app; it follows with `-f` only
+  when a single app is targeted.
+- README install URLs corrected, and the alias example no longer clobbers
+  `~/.bashrc`.
+
+## [0.1.0] - 2022-07-12
+- Initial release: bulk `start` / `stop` / `restart` / `update` / `backup` of
+  docker-compose apps laid out in per-app folders.
+
+[Unreleased]: https://github.com/AdamXweb/DockerDance/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/AdamXweb/DockerDance/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -21,8 +21,9 @@ This provides an easier way to update, restart and backup apps/services.
 
 ### Prerequisites
 - A Unix-like operating system: macOS, Linux, BSD. On Windows: WSL2 is preferred, but cygwin or msys also mostly work.
-- Docker, either with old compose or updated compose plugin
-- Each service contained in a folder within a `docker_volumes` folder with its own `docker-compose.yml`
+- Docker, either with old compose (`docker-compose`) or the updated compose plugin (`docker compose`) — the script detects which you have
+- Each service contained in a folder within a `docker_volumes` folder, with its own compose file (`docker-compose.yml`/`.yaml` or `compose.yml`/`.yaml`). The script finds these folders for you (see `Apps="auto"` below)
+- Optional: [fzf](https://github.com/junegunn/fzf) for a fuzzy app-picker in the interactive menu — the menu works without it
 
 ### Basic Usage
 The folders have been setup for use on a new server to make use of the script's structure.
@@ -91,8 +92,7 @@ Stops all the apps, then starts them up again.
 
 ### Backup
 `./manage.sh backup`
-At the moment the script is limited to backing up files in each directory.
-Its function acts as an all in one for my use; It stops the container, backs up, updates and starts.
+An all-in-one per app: it pulls the latest images **while the app is still running**, stops it gracefully, tars its folder into the `backup` folder, then starts it back up on the new images. Archives are written with `chmod 600` (they contain your `.env` secrets) and store paths relative to `docker_volumes`, so a `restore` is portable. Running twice in one day won't clobber the earlier archive — the second gets a `_HHMMSS` suffix. Set `BACKUP_KEEP=N` to keep only the newest N archives per app.
 
 ### Restore
 `./manage.sh restore linkace`
@@ -118,7 +118,9 @@ Updates the script itself to the latest [GitHub release](https://github.com/Adam
 
 
 ## Environment
-This script is to be used in a linux system as a user with priveleges to modify files. (i.e. root or if your user is part of a group - to mitigate issues backing up files such as databases.)
+This script is meant to run on a Unix-like system as a user with privileges to modify the app files — i.e. root, or a user whose group can read the volume data — so that backing up database files created by root doesn't fail with a permission error.
+
+> **A note on secrets and safety.** App folders usually contain a `.env` with credentials, so the backup archives do too — they're written `chmod 600` (owner-only), and the `backup` folder inherits the permissions of the root-owned `docker_volumes` tree. `restore` never deletes your current data: it moves it aside to `<app>.pre-restore.<timestamp>` and asks for confirmation before extracting. If you sync backups off-box (see below), treat that copy as sensitive too.
 
 ### Folder structure
 The default path is set to `~/docker_volumes` (userhome/docker_volumes).
@@ -143,8 +145,7 @@ userfolder
 ```
 
 ### Backups
-When backups above are completed, they are placed in a backup folder with the name of the service and the date appended on the end.
-The date is designed without a timestamp to be run once a day/week/month. If time is critical, then the `tar` filename can be adjusted for your use.
+When a backup completes, the archive is placed in the `backup` folder named `<service><date>.tar.bz2`. The date is deliberately day-resolution so a daily/weekly/monthly cron run produces one archive per period. If you back up more than once in a day, the extra runs get a `_HHMMSS` suffix instead of overwriting the first. Set `BACKUP_KEEP=N` to prune automatically to the newest N archives per app after each run.
 
 ```
 userfolder
@@ -177,24 +178,33 @@ I have another system that connects and executes an [rsync](https://download.sam
 - the backup folder is created automatically if it doesn't exist yet.
 
 ## Things to improve
-- Code could be refactored as there are multiple repeating elements
-- Restoring
-- More with backups to show processes uploading to external servers.
-- Ability to define target as a remote server or path with more storage.
+- Ability to define the backup target as a remote server or path with more storage
+- A `status` / dashboard view showing every app's state at a glance
+- Health-aware start (wait until containers report healthy before moving on)
+
+See the [CHANGELOG](CHANGELOG.md) for what's landed recently.
 
 ### Cron
-TBC - useful to run on a schedule to update, backup etc.
+The script gives plain, un-coloured output and needs no terminal when run non-interactively, so it drops straight into cron. For example, back up every discovered app nightly at 3am and log it:
+
+`0 3 * * * cd /home/systemadmin/docker_volumes && ./manage.sh backup >> /var/log/dockerdance.log 2>&1`
+
+Set `NOTIFY_WEBHOOK` (easiest in `manage.conf`) to get a Slack/Discord ping when a scheduled run finishes or fails. A lock stops a cron run from overlapping a manual one on the same folder, so you won't get two `stop`/`start` cycles fighting each other.
 
 ### Adding script as an alias
 Depending on your system, you could use something like the below to add the script to your path to just type `appmanage` or whatever command you'd like to nickname it to.
 
 `echo "alias appmanage='$HOME/docker_volumes/manage.sh'" >> ~/.bashrc`
 
+### Tab completion
+A bash completion is included in [contrib/dockerdance-completion.bash](contrib/dockerdance-completion.bash). Source it from your shell startup, pointing at wherever you put the file:
+
+`echo "source /path/to/DockerDance/contrib/dockerdance-completion.bash" >> ~/.bashrc`
+
+It completes the commands first, then app folder names.
+
 ### example folder
-The example folder should be deleted once variables are configured.
-When executing `./manage.sh start` nothing will show as it starts the process detached with `-d`.
-The compose file pulls alpine to show a version if you run `docker compose up`. Helpful for troubleshooting.
-There is a 'test' logic in the script to make sure you change the example variable under `Apps`
+The repo ships an `example` folder with a tiny alpine compose file. Because the default `Apps="auto"` discovers any folder containing a compose file, a fresh clone treats `example` as an app — handy for a first `./manage.sh start` to confirm everything works (it runs detached with `-d`, so nothing prints; `docker compose up` in the folder shows the test message). Delete the folder once you've added your own apps. If you instead pin `Apps="example"` explicitly, the script refuses to run until you change it.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,9 @@ Docker management can be used as the script itself by downloading with a method 
 `USERNAME="systemadmin"` - The user folder that you store the `docker_volumes` in. If you're stuck, type `pwd` to find the path you're in, or `whoami` to get the user name.
 `DOCKER_VOLUMES` defaults to `/home/$USERNAME/docker_volumes/` and can be overwritten in the script, or from the environment without editing anything — handy for MacOS: `DOCKER_VOLUMES="/Users/UserName/docker_volumes/" ./manage.sh start`
 `STOP_TIMEOUT` (default `30`) - seconds to wait for containers to shut down gracefully before docker gives up. Raise it for databases that take a while to flush.
+`BACKUP_KEEP` (unset by default) - when set to a number, only that many most-recent backup archives are kept per app; older ones are pruned after each backup.
+
+Instead of editing the script, all of the above can live in a `manage.conf` file next to `manage.sh` (plain shell assignments, e.g. `Apps="linkace n8n"`). Settings there survive `update-self`.
 
 
 ## Commands
@@ -61,7 +64,9 @@ Every command runs against all the apps in the `Apps` variable by default. To ta
 ### Interactive menu
 `./manage.sh`
 
-Running the script with no arguments on a terminal opens a simple menu: pick a command, then pick an app (or all apps). If [fzf](https://github.com/junegunn/fzf) is installed it's used to fuzzy-pick the app; otherwise a plain numbered menu is shown — no extra dependencies required. Cron and piped usage are unaffected: without a terminal the script prints usage instead of waiting for input.
+Running the script with no arguments on a terminal opens a simple menu: pick a command, then pick an app (or all apps). If [fzf](https://github.com/junegunn/fzf) is installed it's used to fuzzy-pick the app with a live container-status preview pane; otherwise a plain numbered menu is shown with a running/stopped dot per app — no extra dependencies required. Cron and piped usage are unaffected: without a terminal the script prints usage instead of waiting for input.
+
+Colours and spinners appear only on capable terminals and respect [`NO_COLOR`](https://no-color.org). Only one state-changing run is allowed at a time per folder (a lock protects a cron backup from overlapping a manual update). Bash tab-completion is available: see [contrib/dockerdance-completion.bash](contrib/dockerdance-completion.bash).
 
 ### Stop
 `./manage.sh stop`
@@ -100,7 +105,10 @@ Just `apt-get update && apt-get upgrade -y`. Handy for those that don't want to 
 Shows the recent logs for each app. When a single app is targeted (e.g. `./manage.sh logs linkace`) the log is followed live with `-f` — press Ctrl-C to stop.
 
 `./manage.sh help`
-Show usage and the full list of commands.
+Show usage and the full list of commands. `./manage.sh --version` prints the script version.
+
+`./manage.sh update-self`
+Updates the script itself to the latest [GitHub release](https://github.com/AdamXweb/DockerDance/releases): downloads `manage.sh` at the release tag, syntax-checks it, carries your `Apps`/`USERNAME` settings over, and swaps it in place. (Use `manage.conf` for configuration and there's nothing to carry over.)
 
 
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This provides an easier way to update, restart and backup apps/services.
 
 ### Prerequisites
 - A Unix-like operating system: macOS, Linux, BSD. On Windows: WSL2 is preferred, but cygwin or msys also mostly work.
-- Docker, either with old compose (`docker-compose`) or the updated compose plugin (`docker compose`) — the script detects which you have
+- Docker, either with old compose (`docker-compose`) or the updated compose plugin (`docker compose`) — the script detects which you have. If Docker isn't installed, running any command points you to the [official installer](https://docs.docker.com/engine/install/) and can fetch and run Docker's `get.docker.com` script for you (after you confirm)
 - Each service contained in a folder within a `docker_volumes` folder, with its own compose file (`docker-compose.yml`/`.yaml` or `compose.yml`/`.yaml`). The script finds these folders for you (see `Apps="auto"` below)
 - Optional: [fzf](https://github.com/junegunn/fzf) for a fuzzy app-picker in the interactive menu — the menu works without it
 
@@ -30,18 +30,15 @@ The folders have been setup for use on a new server to make use of the script's 
 If you are starting on a new server, you can clone the contents of this repo directly into your user folder with 
 `git clone https://github.com/AdamXweb/DockerDance.git .`
 
-### Precautions
-Please note that this script was designed to work in my environment. The output fit the needs that I face to bulk manage docker apps/services.
-It's a good idea to inspect a script from projects you don't yet know. You can do
-that by downloading the install script first, looking through it so everything looks normal,
-then running it:
+### Installing the script
+DockerDance is just the single `manage.sh` file. Download it **into your `docker_volumes` folder** and make it executable — it's a good idea to inspect a script from a project you don't yet know first, so grab it, read through it, then run it:
 
-#### Downloading the script
-Docker management can be used as the script itself by downloading with a method of your choice, either directly or [from the releases](https://github.com/AdamXweb/DockerDance/releases)
-| Method    | Command                                                                                           |
+| Method    | Command (run from inside your `docker_volumes` folder)                                            |
 | :-------- | :------------------------------------------------------------------------------------------------ |
-| **curl**  | `sh -c "$(curl -fsSL https://raw.githubusercontent.com/AdamXweb/DockerDance/main/docker_volumes/manage.sh)"` |
-| **wget**  | `sh -c "$(wget -O- https://raw.githubusercontent.com/AdamXweb/DockerDance/main/docker_volumes/manage.sh)"`   |
+| **curl**  | `curl -fsSL https://raw.githubusercontent.com/AdamXweb/DockerDance/main/docker_volumes/manage.sh -o manage.sh && chmod +x manage.sh` |
+| **wget**  | `wget -O manage.sh https://raw.githubusercontent.com/AdamXweb/DockerDance/main/docker_volumes/manage.sh && chmod +x manage.sh` |
+
+Then run `./manage.sh` for the interactive menu, or `./manage.sh help` for the command list. You can also pin a specific version [from the releases](https://github.com/AdamXweb/DockerDance/releases); `./manage.sh update-self` updates it to the latest release later. (Prefer git? `git clone https://github.com/AdamXweb/DockerDance.git .` into your user folder gives you the whole `docker_volumes` layout.)
 
 
 #### Customise variables

--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ Docker management can be used as the script itself by downloading with a method 
 `STOP_TIMEOUT` (default `30`) - seconds to wait for containers to shut down gracefully before docker gives up. Raise it for databases that take a while to flush.
 `BACKUP_KEEP` (unset by default) - when set to a number, only that many most-recent backup archives are kept per app; older ones are pruned after each backup.
 
+`NOTIFY_WEBHOOK` (unset by default) - a webhook URL (Slack and Discord formats both work) that gets a message when an update, backup or restore completes or fails. Handy for cron runs. See issue [#3](https://github.com/AdamXweb/DockerDance/issues/3).
+
 Instead of editing the script, all of the above can live in a `manage.conf` file next to `manage.sh` (plain shell assignments, e.g. `Apps="linkace n8n"`). Settings there survive `update-self`.
 
 
@@ -91,8 +93,10 @@ Stops all the apps, then starts them up again.
 At the moment the script is limited to backing up files in each directory.
 Its function acts as an all in one for my use; It stops the container, backs up, updates and starts.
 
-### Restore 
-- todo see issue [#2](https://github.com/AdamXweb/DockerDance/issues/2)
+### Restore
+`./manage.sh restore linkace`
+
+Puts the newest backup archive for the app back in place: stops the app, moves the current folder aside to `<app>.pre-restore.<timestamp>` (nothing is deleted), extracts the archive, and starts the app again. Asks for confirmation and therefore needs a terminal. Pre-v0.2.0 archives (absolute paths) are detected and restored too. Closes issue [#2](https://github.com/AdamXweb/DockerDance/issues/2).
 
 #### Minor commands
 `./manage.sh version`
@@ -166,6 +170,7 @@ I have another system that connects and executes an [rsync](https://download.sam
 - If you'd like to see what's going on with your backups, you can change the `tar` command to `tar -cvjf` adding a v for verbose output to see what files it stops on
 - Running as a local user prompted permission issues when trying to tar the files that were created with root. This led to an early exit of the script.
 - Folder names identified under Apps can have a dot e.g `.n8n` at the front or special characters `uptime-kuma` as long as each entry is separated by a space e.g. `Apps=".n8n uptime-kuma linkace"`.
+- If an app's compose file sits one folder deeper (e.g. `myapp/src/docker-compose.yml`), the script follows it automatically as long as there's only one such folder (issue [#6](https://github.com/AdamXweb/DockerDance/issues/6)).
 - Non executable scripts may need permissions updated with `chmod +x ./docker_volumes/manage.sh` to ensure permissions are executable
 - backups may fail if you run out of space / if this is run on a cron to a local folder.
 - the backup folder is created automatically if it doesn't exist yet.

--- a/README.md
+++ b/README.md
@@ -72,7 +72,12 @@ Two options work with any command (before or after it):
 ### Interactive menu
 `./manage.sh`
 
-Running the script with no arguments on a terminal opens a simple menu: pick a command, then pick the app(s). You can select **more than one app** — with [fzf](https://github.com/junegunn/fzf) press `TAB` to multi-select (with a live container-status preview pane); in the plain numbered fallback enter a space/comma-separated list like `1 3`, or `0` for all. No extra dependencies required. Cron and piped usage are unaffected: without a terminal the script prints usage instead of waiting for input.
+Running the script with no arguments on a terminal opens a menu: pick a command (including `status`, `doctor`, `system-update` and `update-self`), then pick the app(s).
+
+- **With [fzf](https://github.com/junegunn/fzf)** the whole menu is navigable with the **arrow keys** and type-to-filter. On the command list, `Enter` selects and `Esc` quits. On the app list, `TAB` multi-selects (with a live container-status preview pane), `Enter` confirms and `Esc` goes back to the command list.
+- **Without fzf** a numbered menu is shown — type the number *or* the command name; on the app list enter a space/comma-separated list like `1 3` (or `0` for all), and `b` goes back. (Arrow-key navigation needs fzf; a `brew install fzf` / `apt install fzf` is all it takes.)
+
+No extra dependencies are required either way. Cron and piped usage are unaffected: without a terminal the script prints usage instead of waiting for input.
 
 Colours and spinners appear only on capable terminals and respect [`NO_COLOR`](https://no-color.org). Only one state-changing run is allowed at a time per folder (a lock protects a cron backup from overlapping a manual update). Tab-completion is available for bash, zsh and fish in [contrib/](contrib/).
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,8 @@ Docker management can be used as the script itself by downloading with a method 
 
 
 #### Customise variables
-`Apps="example"` - Change to the exact wording of each folder within `docker_volumes` e.g. `Apps="linkace .n8n dashy"`
+`Apps="auto"` (the default) - the script discovers every folder within `docker_volumes` that contains a compose file (`docker-compose.yml`/`.yaml` or `compose.yml`/`.yaml`, or one folder deeper) and manages all of them, in alphabetical order. The `backup` folder and `*.pre-restore.*` folders are skipped. Just drop `manage.sh` into your `docker_volumes` folder and it works.
+To pin the set or the order instead, list the folders explicitly e.g. `Apps="linkace .n8n dashy"`
 `USERNAME="systemadmin"` - The user folder that you store the `docker_volumes` in. If you're stuck, type `pwd` to find the path you're in, or `whoami` to get the user name.
 `DOCKER_VOLUMES` defaults to `/home/$USERNAME/docker_volumes/` and can be overwritten in the script, or from the environment without editing anything — handy for MacOS: `DOCKER_VOLUMES="/Users/UserName/docker_volumes/" ./manage.sh start`
 `STOP_TIMEOUT` (default `30`) - seconds to wait for containers to shut down gracefully before docker gives up. Raise it for databases that take a while to flush.
@@ -57,7 +58,7 @@ Instead of editing the script, all of the above can live in a `manage.conf` file
 
 ## Commands
 There are a few commands you can use with the script.
-Side note, the script executes commands in the order they are listed as e.g. `Apps="1 2 3"` iterates in that order
+Side note, the script executes commands in the order they are listed as e.g. `Apps="1 2 3"` iterates in that order (with `Apps="auto"` the discovered folders run alphabetically)
 
 First, make sure you are in the `docker_volumes` folder, and execute any of the commands below.
 

--- a/README.md
+++ b/README.md
@@ -39,26 +39,28 @@ then running it:
 Docker management can be used as the script itself by downloading with a method of your choice, either directly or [from the releases](https://github.com/AdamXweb/DockerDance/releases)
 | Method    | Command                                                                                           |
 | :-------- | :------------------------------------------------------------------------------------------------ |
-| **curl**  | `sh -c "$(curl -fsSL https://raw.githubusercontent.com/adamxweb/DockerDance/master/docker_volumes/manage.sh)"` |
-| **wget**  | `sh -c "$(wget -O- https://raw.githubusercontent.com/ohmyzsh/DockerDance/master/docker_volumes/manage.sh)"`   |
+| **curl**  | `sh -c "$(curl -fsSL https://raw.githubusercontent.com/AdamXweb/DockerDance/main/docker_volumes/manage.sh)"` |
+| **wget**  | `sh -c "$(wget -O- https://raw.githubusercontent.com/AdamXweb/DockerDance/main/docker_volumes/manage.sh)"`   |
 
 
 #### Customise variables
 `Apps="example"` - Change to the exact wording of each folder within `docker_volumes` e.g. `Apps="linkace .n8n dashy"`
 `USERNAME="systemadmin"` - The user folder that you store the `docker_volumes` in. If you're stuck, type `pwd` to find the path you're in, or `whoami` to get the user name.
-`DOCKER_VOLUMES='/home/'$USERNAME'/docker_volumes/'` can be overwritten with `/Users/UserName/docker_volumes/` for MacOS
+`DOCKER_VOLUMES` defaults to `/home/$USERNAME/docker_volumes/` and can be overwritten in the script, or from the environment without editing anything — handy for MacOS: `DOCKER_VOLUMES="/Users/UserName/docker_volumes/" ./manage.sh start`
 
 
 ## Commands
-There are a few commands you can use with the script. Be warned, as at this stage its use is to manage multiple apps rather than a single one.
+There are a few commands you can use with the script.
 Side note, the script executes commands in the order they are listed as e.g. `Apps="1 2 3"` iterates in that order
 
-First, make sure you are in the `docker_volumes` folder, and execute any of the commands below/
+First, make sure you are in the `docker_volumes` folder, and execute any of the commands below.
+
+Every command runs against all the apps in the `Apps` variable by default. To target one or more specific apps, add their folder names after the command, e.g. `./manage.sh restart linkace` or `./manage.sh update linkace uptime-kuma`.
 
 ### Stop
 `./manage.sh stop`
 
-Stops all the apps by navigating through each folder and stopping the docker process
+Stops all the apps by navigating through each folder and stopping them gracefully with `docker compose stop`, giving databases time to finish writing before shutdown
 
 ### Start
 `./manage.sh start`
@@ -83,13 +85,16 @@ Its function acts as an all in one for my use; It stops the container, backs up,
 
 #### Minor commands
 `./manage.sh version`
-Display versions of images: `docker compose images
-`
+Display versions of images: `docker compose images`
+
 `./manage.sh apt`
-Just `apt update && apt upgrade` & `apt-get update && apt-get upgrade`. Handy for those that don't want to mess with an alias.
+Just `apt-get update && apt-get upgrade -y`. Handy for those that don't want to mess with an alias.
 
 `./manage.sh logs`
-Docker logs.
+Shows the recent logs for each app. When a single app is targeted (e.g. `./manage.sh logs linkace`) the log is followed live with `-f` — press Ctrl-C to stop.
+
+`./manage.sh help`
+Show usage and the full list of commands.
 
 
 
@@ -149,7 +154,7 @@ I have another system that connects and executes an [rsync](https://download.sam
 - Folder names identified under Apps can have a dot e.g `.n8n` at the front or special characters `uptime-kuma` as long as each entry is separated by a space e.g. `Apps=".n8n uptime-kuma linkace"`.
 - Non executable scripts may need permissions updated with `chmod +x ./docker_volumes/manage.sh` to ensure permissions are executable
 - backups may fail if you run out of space / if this is run on a cron to a local folder.
-- backups may fail if you don't have the backup folder. Error may include `Cannot open: No such file or directory tar (child): Error is not recoverable: exiting now`
+- the backup folder is created automatically if it doesn't exist yet.
 
 ## Things to improve
 - Code could be refactored as there are multiple repeating elements
@@ -163,7 +168,7 @@ TBC - useful to run on a schedule to update, backup etc.
 ### Adding script as an alias
 Depending on your system, you could use something like the below to add the script to your path to just type `appmanage` or whatever command you'd like to nickname it to.
 
-`echo "alias appmanage='home/systemadmin/docker_volumes/manage.sh" > ~/.bashrc`
+`echo "alias appmanage='$HOME/docker_volumes/manage.sh'" >> ~/.bashrc`
 
 ### example folder
 The example folder should be deleted once variables are configured.

--- a/README.md
+++ b/README.md
@@ -102,8 +102,8 @@ Puts the newest backup archive for the app back in place: stops the app, moves t
 `./manage.sh version`
 Display versions of images: `docker compose images`
 
-`./manage.sh apt`
-Just `apt-get update && apt-get upgrade -y`. Handy for those that don't want to mess with an alias.
+`./manage.sh system-update`
+Updates the host OS packages with whatever package manager the system has — `apt-get` (Debian/Ubuntu), `dnf` (Fedora/RHEL), `yum`, `pacman` (Arch), `zypper` (openSUSE), `apk` (Alpine) or `brew` (macOS) — detected in that order. Distro managers need root (it tells you to `sudo`); Homebrew refuses root and must run as your normal user. `./manage.sh apt` still works as an alias.
 
 `./manage.sh logs`
 Shows the recent logs for each app. When a single app is targeted (e.g. `./manage.sh logs linkace`) the log is followed live with `-f` — press Ctrl-C to stop.

--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ To pin the set or the order instead, list the folders explicitly e.g. `Apps="lin
 `USERNAME="systemadmin"` - The user folder that you store the `docker_volumes` in. If you're stuck, type `pwd` to find the path you're in, or `whoami` to get the user name.
 `DOCKER_VOLUMES` defaults to `/home/$USERNAME/docker_volumes/` and can be overwritten in the script, or from the environment without editing anything — handy for MacOS: `DOCKER_VOLUMES="/Users/UserName/docker_volumes/" ./manage.sh start`
 `STOP_TIMEOUT` (default `30`) - seconds to wait for containers to shut down gracefully before docker gives up. Raise it for databases that take a while to flush.
+`HEALTH_TIMEOUT` (default `60`) - after starting an app, seconds to wait for its containers to become healthy (or just running, if they have no healthcheck) before moving on. Set `0` to skip the wait entirely.
+`PARALLEL_PULLS` (default `3`) - how many image pulls `update`/`backup` run at once. Set `1` for the old one-at-a-time behaviour.
 `BACKUP_KEEP` (unset by default) - when set to a number, only that many most-recent backup archives are kept per app; older ones are pruned after each backup.
 
 `NOTIFY_WEBHOOK` (unset by default) - a webhook URL (Slack and Discord formats both work) that gets a message when an update, backup or restore completes or fails. Handy for cron runs. See issue [#3](https://github.com/AdamXweb/DockerDance/issues/3).
@@ -65,12 +67,17 @@ First, make sure you are in the `docker_volumes` folder, and execute any of the 
 
 Every command runs against all the apps in the `Apps` variable by default. To target one or more specific apps, add their folder names after the command, e.g. `./manage.sh restart linkace` or `./manage.sh update linkace uptime-kuma`.
 
+Two options work with any command (before or after it):
+- `--dry-run` prints exactly what would happen — which apps get pulled, stopped, backed up, started — without touching anything.
+- `-y` / `--yes` skips confirmation prompts (so `update` and `restore` can run unattended).
+- `--no-color` turns off coloured output (as does setting `NO_COLOR`).
+
 ### Interactive menu
 `./manage.sh`
 
-Running the script with no arguments on a terminal opens a simple menu: pick a command, then pick an app (or all apps). If [fzf](https://github.com/junegunn/fzf) is installed it's used to fuzzy-pick the app with a live container-status preview pane; otherwise a plain numbered menu is shown with a running/stopped dot per app — no extra dependencies required. Cron and piped usage are unaffected: without a terminal the script prints usage instead of waiting for input.
+Running the script with no arguments on a terminal opens a simple menu: pick a command, then pick the app(s). You can select **more than one app** — with [fzf](https://github.com/junegunn/fzf) press `TAB` to multi-select (with a live container-status preview pane); in the plain numbered fallback enter a space/comma-separated list like `1 3`, or `0` for all. No extra dependencies required. Cron and piped usage are unaffected: without a terminal the script prints usage instead of waiting for input.
 
-Colours and spinners appear only on capable terminals and respect [`NO_COLOR`](https://no-color.org). Only one state-changing run is allowed at a time per folder (a lock protects a cron backup from overlapping a manual update). Bash tab-completion is available: see [contrib/dockerdance-completion.bash](contrib/dockerdance-completion.bash).
+Colours and spinners appear only on capable terminals and respect [`NO_COLOR`](https://no-color.org). Only one state-changing run is allowed at a time per folder (a lock protects a cron backup from overlapping a manual update). Tab-completion is available for bash, zsh and fish in [contrib/](contrib/).
 
 ### Stop
 `./manage.sh stop`
@@ -84,7 +91,7 @@ Starts all the apps by navigating through each folder and starting with `docker 
 
 ### Update
 `./manage.sh update`
-Pulls the latest images **while each app is still running**, then stops and recreates the container — so downtime is just the stop/start window, not the whole download.
+Pulls the latest images for all target apps **in parallel** (up to `PARALLEL_PULLS` at once), then stops and recreates each container on the new image — so downtime is just the stop/start window, not the download. On a terminal it asks for confirmation first (skip with `-y`); an app whose pull fails is left running on its current image and reported. After starting, it waits for each app to report healthy (see [Health](#health) below).
 
 ### Restart
 `./manage.sh restart`
@@ -97,11 +104,23 @@ An all-in-one per app: it pulls the latest images **while the app is still runni
 ### Restore
 `./manage.sh restore linkace`
 
-Puts the newest backup archive for the app back in place: stops the app, moves the current folder aside to `<app>.pre-restore.<timestamp>` (nothing is deleted), extracts the archive, and starts the app again. Asks for confirmation and therefore needs a terminal. Pre-v0.2.0 archives (absolute paths) are detected and restored too. Closes issue [#2](https://github.com/AdamXweb/DockerDance/issues/2).
+Puts the newest backup archive for the app back in place: stops the app, moves the current folder aside to `<app>.pre-restore.<timestamp>` (nothing is deleted), extracts the archive, and starts the app again. Asks for confirmation (needs a terminal, or pass `-y`). Pre-v0.2.0 archives (absolute paths) are detected and restored too. Archives are treated as untrusted: extraction happens in an isolated staging area, any path-traversal (`..`) member is refused, and only the app's own folder is promoted — a tampered archive can't write elsewhere on disk. Closes issue [#2](https://github.com/AdamXweb/DockerDance/issues/2).
+
+### Status
+`./manage.sh status`
+
+A dashboard with one line per app: a coloured running/stopped dot, container state (`up` / `N/M up` / `stopped`), the image in use, and health. Read-only — a quick "is everything OK?" at a glance.
+
+<a name="health"></a>
+### Health
+After starting an app (via `start`, `restart`, `update`, `backup` or `restore`), the script waits for its containers to come up rather than just assuming they will. Containers with a healthcheck must report `healthy`; those without just need to be running. The result line becomes e.g. `linkace started, healthy`, or a warning if a container is unhealthy or still starting after `HEALTH_TIMEOUT` (default 60s; set `0` to skip the wait). The wait is best-effort and never fails the run.
 
 #### Minor commands
 `./manage.sh version`
 Display versions of images: `docker compose images`
+
+`./manage.sh doctor`
+A read-only environment check: docker daemon reachability, the compose flavour in use, whether `curl`/`wget`/`fzf` are present, the package manager `system-update` would use, `tar` safety, whether `DOCKER_VOLUMES` is writable, `manage.conf`, a stale lock, the effective settings and the discovered app list. Handy for first-run setup and bug reports.
 
 `./manage.sh system-update`
 Updates the host OS packages with whatever package manager the system has — `apt-get` (Debian/Ubuntu), `dnf` (Fedora/RHEL), `yum`, `pacman` (Arch), `zypper` (openSUSE), `apk` (Alpine) or `brew` (macOS) — detected in that order. Distro managers need root (it tells you to `sudo`); Homebrew refuses root and must run as your normal user. `./manage.sh apt` still works as an alias.

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ An all-in-one per app: it pulls the latest images **while the app is still runni
 ### Restore
 `./manage.sh restore linkace`
 
-Puts the newest backup archive for the app back in place: stops the app, moves the current folder aside to `<app>.pre-restore.<timestamp>` (nothing is deleted), extracts the archive, and starts the app again. Asks for confirmation (needs a terminal, or pass `-y`). Pre-v0.2.0 archives (absolute paths) are detected and restored too. Archives are treated as untrusted: extraction happens in an isolated staging area, any path-traversal (`..`) member is refused, and only the app's own folder is promoted — a tampered archive can't write elsewhere on disk. Closes issue [#2](https://github.com/AdamXweb/DockerDance/issues/2).
+Puts the newest backup archive for the app back in place: stops the app, moves the current folder aside to `<app>.pre-restore.<timestamp>` (nothing is deleted), extracts the archive, and starts the app again. Asks for confirmation (needs a terminal, or pass `-y`). Older v0.1.0-era archives (absolute paths) are detected and restored too. Archives are treated as untrusted: extraction happens in an isolated staging area, any path-traversal (`..`) member is refused, and only the app's own folder is promoted — a tampered archive can't write elsewhere on disk. Closes issue [#2](https://github.com/AdamXweb/DockerDance/issues/2).
 
 ### Status
 `./manage.sh status`

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Docker management can be used as the script itself by downloading with a method 
 `Apps="example"` - Change to the exact wording of each folder within `docker_volumes` e.g. `Apps="linkace .n8n dashy"`
 `USERNAME="systemadmin"` - The user folder that you store the `docker_volumes` in. If you're stuck, type `pwd` to find the path you're in, or `whoami` to get the user name.
 `DOCKER_VOLUMES` defaults to `/home/$USERNAME/docker_volumes/` and can be overwritten in the script, or from the environment without editing anything — handy for MacOS: `DOCKER_VOLUMES="/Users/UserName/docker_volumes/" ./manage.sh start`
+`STOP_TIMEOUT` (default `30`) - seconds to wait for containers to shut down gracefully before docker gives up. Raise it for databases that take a while to flush.
 
 
 ## Commands
@@ -74,7 +75,7 @@ Starts all the apps by navigating through each folder and starting with `docker 
 
 ### Update
 `./manage.sh update`
-Stops all the apps, pulls the latest version and recreates container
+Pulls the latest images **while each app is still running**, then stops and recreates the container — so downtime is just the stop/start window, not the whole download.
 
 ### Restart
 `./manage.sh restart`

--- a/README.md
+++ b/README.md
@@ -57,6 +57,11 @@ First, make sure you are in the `docker_volumes` folder, and execute any of the 
 
 Every command runs against all the apps in the `Apps` variable by default. To target one or more specific apps, add their folder names after the command, e.g. `./manage.sh restart linkace` or `./manage.sh update linkace uptime-kuma`.
 
+### Interactive menu
+`./manage.sh`
+
+Running the script with no arguments on a terminal opens a simple menu: pick a command, then pick an app (or all apps). If [fzf](https://github.com/junegunn/fzf) is installed it's used to fuzzy-pick the app; otherwise a plain numbered menu is shown — no extra dependencies required. Cron and piped usage are unaffected: without a terminal the script prints usage instead of waiting for input.
+
 ### Stop
 `./manage.sh stop`
 

--- a/contrib/dockerdance-completion.bash
+++ b/contrib/dockerdance-completion.bash
@@ -7,7 +7,7 @@
 _dockerdance() {
   local cur commands
   cur=${COMP_WORDS[COMP_CWORD]}
-  commands="start stop restart update backup restore logs version running apt update-self help"
+  commands="start stop restart update backup restore logs version running system-update update-self help"
   if [ "$COMP_CWORD" -eq 1 ]; then
     mapfile -t COMPREPLY < <(compgen -W "$commands" -- "$cur")
   else

--- a/contrib/dockerdance-completion.bash
+++ b/contrib/dockerdance-completion.bash
@@ -1,7 +1,7 @@
 # shellcheck shell=bash
 # Bash completion for DockerDance's manage.sh
-# Install: source this file from ~/.bashrc, e.g.
-#   echo "source $HOME/docker_volumes/contrib/dockerdance-completion.bash" >> ~/.bashrc
+# Install: source this file from ~/.bashrc, pointing at wherever you placed it, e.g.
+#   echo "source /path/to/DockerDance/contrib/dockerdance-completion.bash" >> ~/.bashrc
 # Completes commands first, then app folder names in the current directory.
 
 _dockerdance() {

--- a/contrib/dockerdance-completion.bash
+++ b/contrib/dockerdance-completion.bash
@@ -5,10 +5,13 @@
 # Completes commands first, then app folder names in the current directory.
 
 _dockerdance() {
-  local cur commands
+  local cur commands flags
   cur=${COMP_WORDS[COMP_CWORD]}
-  commands="start stop restart update backup restore logs version running system-update update-self help"
-  if [ "$COMP_CWORD" -eq 1 ]; then
+  commands="start stop restart update backup restore status logs version running doctor system-update update-self help"
+  flags="--dry-run --yes --no-color --version --help"
+  if [[ "$cur" == -* ]]; then
+    mapfile -t COMPREPLY < <(compgen -W "$flags" -- "$cur")
+  elif [ "$COMP_CWORD" -eq 1 ]; then
     mapfile -t COMPREPLY < <(compgen -W "$commands" -- "$cur")
   else
     # App folders live alongside manage.sh; skip the backup folder itself

--- a/contrib/dockerdance-completion.bash
+++ b/contrib/dockerdance-completion.bash
@@ -1,0 +1,19 @@
+# shellcheck shell=bash
+# Bash completion for DockerDance's manage.sh
+# Install: source this file from ~/.bashrc, e.g.
+#   echo "source $HOME/docker_volumes/contrib/dockerdance-completion.bash" >> ~/.bashrc
+# Completes commands first, then app folder names in the current directory.
+
+_dockerdance() {
+  local cur commands
+  cur=${COMP_WORDS[COMP_CWORD]}
+  commands="start stop restart update backup logs version running apt update-self help"
+  if [ "$COMP_CWORD" -eq 1 ]; then
+    mapfile -t COMPREPLY < <(compgen -W "$commands" -- "$cur")
+  else
+    # App folders live alongside manage.sh; skip the backup folder itself
+    mapfile -t COMPREPLY < <(compgen -d -X 'backup' -- "$cur")
+  fi
+}
+
+complete -F _dockerdance manage.sh ./manage.sh appmanage

--- a/contrib/dockerdance-completion.bash
+++ b/contrib/dockerdance-completion.bash
@@ -7,7 +7,7 @@
 _dockerdance() {
   local cur commands
   cur=${COMP_WORDS[COMP_CWORD]}
-  commands="start stop restart update backup logs version running apt update-self help"
+  commands="start stop restart update backup restore logs version running apt update-self help"
   if [ "$COMP_CWORD" -eq 1 ]; then
     mapfile -t COMPREPLY < <(compgen -W "$commands" -- "$cur")
   else

--- a/contrib/dockerdance-completion.zsh
+++ b/contrib/dockerdance-completion.zsh
@@ -1,0 +1,42 @@
+#compdef manage.sh appmanage
+# Zsh completion for DockerDance's manage.sh.
+# Install: copy this file to a directory on your $fpath named "_manage.sh"
+# (e.g. ~/.zsh/completions/_manage.sh) and make sure that directory is added
+# before compinit runs in ~/.zshrc:
+#   fpath=(~/.zsh/completions $fpath)
+#   autoload -Uz compinit && compinit
+# Completes commands first, then app folder names in the current directory.
+
+_dockerdance() {
+  local -a commands
+  commands=(
+    'start:Start apps'
+    'stop:Stop apps gracefully'
+    'restart:Restart apps'
+    'update:Pull new images and recreate containers'
+    'backup:Archive app folders, then update'
+    'restore:Restore the newest backup'
+    'status:Dashboard of every app'\''s state'
+    'logs:Show recent logs'
+    'version:Show image versions'
+    'running:List running containers'
+    'doctor:Check the environment (read-only)'
+    'system-update:Update host OS packages'
+    'update-self:Update this script'
+    'help:Show help'
+  )
+
+  _arguments -C \
+    '--dry-run[Show what would happen without doing it]' \
+    '(-y --yes)'{-y,--yes}'[Skip confirmation prompts]' \
+    '--no-color[Disable coloured output]' \
+    '1:command:->command' \
+    '*:app:->app'
+
+  case "$state" in
+    command) _describe -t commands 'command' commands ;;
+    app)     _path_files -/ ;;
+  esac
+}
+
+_dockerdance "$@"

--- a/contrib/dockerdance.fish
+++ b/contrib/dockerdance.fish
@@ -1,0 +1,32 @@
+# Fish completion for DockerDance's manage.sh.
+# Install: copy to ~/.config/fish/completions/manage.sh.fish
+# (works when the tool is invoked as `manage.sh` or an `appmanage` alias).
+# Completes commands first, then app folder names in the current directory.
+
+set -l dd_cmds start stop restart update backup restore status logs version running doctor system-update update-self help
+
+for cmd in manage.sh appmanage
+    # Commands (only as the first argument)
+    complete -c $cmd -f -n "not __fish_seen_subcommand_from $dd_cmds" -a start         -d 'Start apps'
+    complete -c $cmd -f -n "not __fish_seen_subcommand_from $dd_cmds" -a stop          -d 'Stop apps gracefully'
+    complete -c $cmd -f -n "not __fish_seen_subcommand_from $dd_cmds" -a restart       -d 'Restart apps'
+    complete -c $cmd -f -n "not __fish_seen_subcommand_from $dd_cmds" -a update        -d 'Pull new images and recreate'
+    complete -c $cmd -f -n "not __fish_seen_subcommand_from $dd_cmds" -a backup        -d 'Archive app folders, then update'
+    complete -c $cmd -f -n "not __fish_seen_subcommand_from $dd_cmds" -a restore       -d 'Restore the newest backup'
+    complete -c $cmd -f -n "not __fish_seen_subcommand_from $dd_cmds" -a status        -d 'Dashboard of app state'
+    complete -c $cmd -f -n "not __fish_seen_subcommand_from $dd_cmds" -a logs          -d 'Show recent logs'
+    complete -c $cmd -f -n "not __fish_seen_subcommand_from $dd_cmds" -a version       -d 'Show image versions'
+    complete -c $cmd -f -n "not __fish_seen_subcommand_from $dd_cmds" -a running       -d 'List running containers'
+    complete -c $cmd -f -n "not __fish_seen_subcommand_from $dd_cmds" -a doctor        -d 'Check the environment'
+    complete -c $cmd -f -n "not __fish_seen_subcommand_from $dd_cmds" -a system-update -d 'Update host OS packages'
+    complete -c $cmd -f -n "not __fish_seen_subcommand_from $dd_cmds" -a update-self   -d 'Update this script'
+    complete -c $cmd -f -n "not __fish_seen_subcommand_from $dd_cmds" -a help          -d 'Show help'
+
+    # Options
+    complete -c $cmd -l dry-run  -d 'Show what would happen without doing it'
+    complete -c $cmd -s y -l yes -d 'Skip confirmation prompts'
+    complete -c $cmd -l no-color -d 'Disable coloured output'
+
+    # App folder names once a command is present
+    complete -c $cmd -f -n "__fish_seen_subcommand_from $dd_cmds" -a '(__fish_complete_directories)'
+end

--- a/docker_volumes/manage.conf.example
+++ b/docker_volumes/manage.conf.example
@@ -1,0 +1,34 @@
+# DockerDance configuration - copy to "manage.conf" next to manage.sh and edit.
+#
+#   cp manage.conf.example manage.conf
+#
+# manage.conf is sourced by manage.sh at startup, so it's plain shell:
+# VAR="value", one per line, '#' starts a comment. Keeping your settings here
+# (rather than editing manage.sh) means they survive `./manage.sh update-self`.
+# Everything below is optional and shown with its default.
+
+# Which apps to manage.
+#   "auto"  - discover every folder here that has a compose file (the default)
+#   a list  - pin the exact set and order, e.g. "linkace .n8n uptime-kuma"
+#Apps="auto"
+
+# The user whose home holds docker_volumes. Only used to build the default
+# DOCKER_VOLUMES path below; ignored if you set DOCKER_VOLUMES directly.
+#USERNAME="systemadmin"
+
+# Absolute path to the docker_volumes folder (note the trailing slash).
+# Defaults to /home/$USERNAME/docker_volumes/. On macOS, for example:
+#DOCKER_VOLUMES="/Users/yourname/docker_volumes/"
+
+# Seconds to wait for a container to stop gracefully before docker forces it.
+# Raise it for databases that take a while to flush to disk.
+#STOP_TIMEOUT="30"
+
+# Keep only the newest N backup archives per app (older ones are pruned after
+# each backup). Leave unset to keep every archive.
+#BACKUP_KEEP="7"
+
+# Webhook pinged when update/backup/restore finishes or fails. The payload
+# carries both a Slack "text" and a Discord "content" field, so a Slack or
+# Discord incoming-webhook URL works as-is.
+#NOTIFY_WEBHOOK="https://hooks.slack.com/services/XXXX/YYYY/ZZZZ"

--- a/docker_volumes/manage.conf.example
+++ b/docker_volumes/manage.conf.example
@@ -24,6 +24,13 @@
 # Raise it for databases that take a while to flush to disk.
 #STOP_TIMEOUT="30"
 
+# Seconds to wait after starting an app for its containers to become healthy
+# (or just running, if they have no healthcheck). Set 0 to skip the wait.
+#HEALTH_TIMEOUT="60"
+
+# How many image pulls update/backup run at once. Set 1 for sequential pulls.
+#PARALLEL_PULLS="3"
+
 # Keep only the newest N backup archives per app (older ones are pruned after
 # each backup). Leave unset to keep every archive.
 #BACKUP_KEEP="7"

--- a/docker_volumes/manage.sh
+++ b/docker_volumes/manage.sh
@@ -8,33 +8,19 @@ USERNAME="systemadmin"
 
 #Specific to Linux. Can change these if needed
 #Set folder from root to avoid permission issues if running script as different user. (this would be /home/systemadmin/docker_volumes)
-DOCKER_VOLUMES='/home/'$USERNAME'/docker_volumes/'
+#Can also be overridden from the environment, e.g. for MacOS:
+#  DOCKER_VOLUMES="/Users/yourname/docker_volumes/" ./manage.sh start
+DOCKER_VOLUMES="${DOCKER_VOLUMES:-/home/$USERNAME/docker_volumes/}"
 #Target is the folder within that the tar will save to if running a backup.
-TARGET=$DOCKER_VOLUMES'backup/'
+TARGET="${DOCKER_VOLUMES}backup/"
 
 
-#Check Docker is installed
-DOCKER_VERSION=`docker --version`
-if [ "$?" -ne "0" ]; then
-  echo "Please install Docker before proceeding."
-  exit 1
+#Add styling (only when writing to a terminal that supports it)
+bold="" normal=""
+if [ -t 1 ] && [ -n "${TERM:-}" ] && [ "${TERM:-}" != "dumb" ] && command -v tput >/dev/null 2>&1; then
+  bold=$(tput bold) || bold=""
+  normal=$(tput sgr0) || normal=""
 fi
-
-#Check which docker command to use
-DOCKER_COMPOSE_COMMAND="docker compose"
-if ! $DOCKER_COMPOSE_COMMAND > /dev/null 2>&1; then
-  DOCKER_COMPOSE_COMMAND="docker-compose"
-fi
-
-#Check to see if variables have been set above.
-checkDefault() {
-  if [ $Apps == "example" ]; then echo "Please change the default app to include your apps" && exit 1; fi
-}
-
-
-#Add stlying
-bold=$(tput bold)
-normal=$(tput sgr0)
 
 actioninfo() {
   echo "${bold}[action]:${normal} ⇒ $1"
@@ -45,145 +31,264 @@ ok() {
 success() {
   echo "${bold}[success]${normal} - $1"
 }
+error() {
+  echo "${bold}[error]${normal} - $1" >&2
+}
 
-# TODO use getopt at some stage to make a flag -a set variable to $apps
-COMMAND=$1 && shift 1
+#Check Docker is installed, the daemon is reachable and compose is available
+DOCKER_COMPOSE_COMMAND=""
+require_docker() {
+  if ! command -v docker >/dev/null 2>&1; then
+    error "Please install Docker before proceeding."
+    exit 1
+  fi
+  if ! docker info >/dev/null 2>&1; then
+    error "Docker is installed but not reachable. Is the daemon running, and does your user have permission to use it?"
+    exit 1
+  fi
+  #Check which docker compose command to use
+  if docker compose version >/dev/null 2>&1; then
+    DOCKER_COMPOSE_COMMAND="docker compose"
+  elif command -v docker-compose >/dev/null 2>&1; then
+    DOCKER_COMPOSE_COMMAND="docker-compose"
+  else
+    error "Neither the 'docker compose' plugin nor 'docker-compose' was found."
+    exit 1
+  fi
+}
 
-case "$COMMAND" in
-  'backup' )
-    checkDefault
-    actioninfo "${bold}Backing up${normal} apps including:"
-    for i in $Apps
-    do
-      echo "⇒ $i"
-    done
-    echo "---"
-    for i in $Apps
-    do
-        echo "Stopping ${bold}$i${normal}"
-        cd $i
-        $DOCKER_COMPOSE_COMMAND kill
-        ok 
-        echo "Backing up $i"
-        tar -cjf $TARGET$i$(date '+%Y-%m-%d').tar.bz2 $DOCKER_VOLUMES$i
-        ok "$i is backed up"
-        echo "Updating $i"
-        $DOCKER_COMPOSE_COMMAND pull
-        ok "Images up to date. Starting all services."
-        $DOCKER_COMPOSE_COMMAND up -d
-        ok "$i backed up, updated and running"
-        cd ..
-    done
-    success "Backing up completed"
-    ;;
-  'restore' )
-    echo "Coming soon:"
-    ;;
-  'logs' )
-    for i in $Apps
-    do
-      echo "Getting ${bold}$i${normal} logs"
-      cd $i
-      $DOCKER_COMPOSE_COMMAND logs -f
-      cd ..
-    done
-    ;;
-  'update' )
-    checkDefault
-    actioninfo "${bold}Updating all services.${normal}"
-    for i in $Apps
-    do
-      echo "⇒ $i"
-    done
-    echo "---"
-    for i in $Apps
-    do
-        echo "Stopping ${bold}$i${normal}"
-        cd $i
-        $DOCKER_COMPOSE_COMMAND kill
-        ok "$i stopped"
-        echo "Updating $i"
-        $DOCKER_COMPOSE_COMMAND pull
-        ok "Images up to date. Starting all services."
-        $DOCKER_COMPOSE_COMMAND up -d
-        ok "$i Updated and running"
-        cd ..
-    done
-    success "Services updated. Give them a moment to warm up."
-    ;;
-  'stop' )
-    checkDefault
-    actioninfo "${bold}Stopping${normal} all services:"
-    for i in $Apps
-    do
-      echo "⇒ $i"
-    done
-    echo "---"
-    for i in $Apps
-    do
-        echo "Stopping ${bold}$i${normal}"
-        cd $i
-        $DOCKER_COMPOSE_COMMAND kill
-        ok "$i stopped"
-        cd ..
-    done
-    success "Services stopped"
-    ;;
-  'start' )
-    checkDefault
-    actioninfo "${bold}Starting${normal} all services"
-    for i in $Apps
-    do
-      echo "⇒ $i"
-    done
-    echo "---"
-    for i in $Apps
-    do
-        echo "Starting ${bold}$i${normal}"
-        cd $i
-        $DOCKER_COMPOSE_COMMAND up -d
-        ok "$i started"
-        cd ..
-    done
-    success "Services started. Give them a moment to warm up."
-    ;;
-  'restart' )
-    checkDefault
-    actioninfo "${bold}Restarting${normal} all services"
-    for i in $Apps
-    do
-        echo "Stopping ${bold}$i${normal}"
-        cd $i
-        $DOCKER_COMPOSE_COMMAND kill
-        ok "$i stopped"
-        $DOCKER_COMPOSE_COMMAND up -d
-        ok "$i restarted"
-        cd ..
-    done
-    success "Services restarted. Give them a moment to warm up."
-    ;;
-  'version' )
-    for i in $Apps
-      do
-          echo "Getting ${bold}$i${normal} version"
-          cd $i
-          $DOCKER_COMPOSE_COMMAND images
-          cd ..
+compose() {
+  # shellcheck disable=SC2086 # intentionally unquoted: may be the two words 'docker compose'
+  $DOCKER_COMPOSE_COMMAND "$@"
+}
+
+#Check to see if variables have been set above.
+checkDefault() {
+  #Apps passed on the command line don't need the variable configured
+  if [ "$APPS_OVERRIDDEN" = "1" ]; then
+    return 0
+  fi
+  if [ "$Apps" = "example" ]; then
+    error "Please change the default 'Apps' variable to include your apps (or pass app names after the command)."
+    exit 1
+  fi
+}
+
+enter_app() {
+  if [ ! -d "$1" ]; then
+    error "No folder named '$1' here. Run this from the docker_volumes folder and check the Apps variable / arguments."
+    exit 1
+  fi
+  cd "$1"
+}
+
+list_apps() {
+  for app in "$@"; do
+    echo "⇒ $app"
+  done
+  echo "---"
+}
+
+start_app() {
+  echo "Starting ${bold}$1${normal}"
+  enter_app "$1"
+  compose up -d
+  ok "$1 started"
+  cd ..
+}
+
+stop_app() {
+  echo "Stopping ${bold}$1${normal}"
+  enter_app "$1"
+  #stop (not kill) shuts containers down gracefully so databases can finish writing
+  compose stop
+  ok "$1 stopped"
+  cd ..
+}
+
+restart_app() {
+  echo "Restarting ${bold}$1${normal}"
+  enter_app "$1"
+  compose stop
+  ok "$1 stopped"
+  compose up -d
+  ok "$1 restarted"
+  cd ..
+}
+
+update_app() {
+  echo "Stopping ${bold}$1${normal}"
+  enter_app "$1"
+  compose stop
+  ok "$1 stopped"
+  echo "Updating $1"
+  compose pull
+  ok "Images up to date. Starting all services."
+  compose up -d
+  ok "$1 updated and running"
+  cd ..
+}
+
+backup_app() {
+  echo "Stopping ${bold}$1${normal}"
+  enter_app "$1"
+  compose stop
+  ok "$1 stopped"
+  echo "Backing up $1"
+  mkdir -p "$TARGET"
+  tar -cjf "${TARGET}${1}$(date '+%Y-%m-%d').tar.bz2" "${DOCKER_VOLUMES}${1}"
+  ok "$1 is backed up"
+  echo "Updating $1"
+  compose pull
+  ok "Images up to date. Starting all services."
+  compose up -d
+  ok "$1 backed up, updated and running"
+  cd ..
+}
+
+usage() {
+  cat <<EOF
+${bold}DockerDance${normal} - bulk manage docker compose apps
+
+Usage: ./manage.sh <command> [app ...]
+
+Commands:
+  start     Start apps (docker compose up -d)
+  stop      Stop apps gracefully (docker compose stop)
+  restart   Stop apps, then start them again
+  update    Stop apps, pull the latest images and start them again
+  backup    Stop apps, tar their folders into the backup folder, then update and start them
+  logs      Show recent logs (follows the log when a single app is targeted)
+  version   Show the image versions each app is using
+  running   List running containers (docker ps)
+  apt       Update the host system with apt-get (Debian/Ubuntu)
+  help      Show this help
+
+Commands run against every app in the Apps variable. Pass one or more
+folder names to target specific apps instead, e.g. ./manage.sh restart linkace
+EOF
+}
+
+run_command() {
+  menu_command=$1
+  # shellcheck disable=SC2086 # Apps is an intentionally space-separated list
+  set -- $Apps
+  case "$menu_command" in
+    'backup' )
+      checkDefault
+      require_docker
+      actioninfo "${bold}Backing up${normal} apps including:"
+      list_apps "$@"
+      for app in "$@"; do
+        backup_app "$app"
       done
-    ;;
+      success "Backing up completed"
+      ;;
+    'restore' )
+      echo "Coming soon:"
+      ;;
+    'logs' )
+      checkDefault
+      require_docker
+      if [ $# -eq 1 ]; then
+        echo "Following ${bold}$1${normal} logs (Ctrl-C to stop)"
+        enter_app "$1"
+        compose logs -f
+        cd ..
+      else
+        for app in "$@"; do
+          echo "Getting ${bold}$app${normal} logs"
+          enter_app "$app"
+          compose logs --tail=20
+          cd ..
+        done
+      fi
+      ;;
+    'update' )
+      checkDefault
+      require_docker
+      actioninfo "${bold}Updating all services.${normal}"
+      list_apps "$@"
+      for app in "$@"; do
+        update_app "$app"
+      done
+      success "Services updated. Give them a moment to warm up."
+      ;;
+    'stop' )
+      checkDefault
+      require_docker
+      actioninfo "${bold}Stopping${normal} all services:"
+      list_apps "$@"
+      for app in "$@"; do
+        stop_app "$app"
+      done
+      success "Services stopped"
+      ;;
+    'start' )
+      checkDefault
+      require_docker
+      actioninfo "${bold}Starting${normal} all services"
+      list_apps "$@"
+      for app in "$@"; do
+        start_app "$app"
+      done
+      success "Services started. Give them a moment to warm up."
+      ;;
+    'restart' )
+      checkDefault
+      require_docker
+      actioninfo "${bold}Restarting${normal} all services"
+      for app in "$@"; do
+        restart_app "$app"
+      done
+      success "Services restarted. Give them a moment to warm up."
+      ;;
+    'version' )
+      checkDefault
+      require_docker
+      for app in "$@"; do
+        echo "Getting ${bold}$app${normal} version"
+        enter_app "$app"
+        compose images
+        cd ..
+      done
+      ;;
     'running' )
-    echo "Getting all running services"
-    docker ps
-    ;;
+      require_docker
+      echo "Getting all running services"
+      docker ps
+      ;;
     'apt' )
-    echo "Updating system with apt."
-    apt update && apt upgrade -y
-    apt-get update && apt upgrade -y
-    success "System updated"
-    ;;
-  * )
-    echo "Unknown command"
-    ;;
-esac
+      if ! command -v apt-get >/dev/null 2>&1; then
+        error "apt-get not found. This command is only for Debian/Ubuntu systems."
+        exit 1
+      fi
+      echo "Updating system with apt."
+      apt-get update && apt-get upgrade -y
+      success "System updated"
+      ;;
+    'help' | '-h' | '--help' )
+      usage
+      ;;
+    * )
+      error "Unknown command '$menu_command'"
+      usage
+      exit 1
+      ;;
+  esac
+}
 
-exec "$@"
+APPS_OVERRIDDEN=0
+if [ $# -eq 0 ]; then
+  usage
+  exit 1
+fi
+
+COMMAND=$1
+shift
+if [ $# -gt 0 ]; then
+  #Remaining arguments target specific apps, e.g. ./manage.sh restart linkace
+  Apps="$*"
+  APPS_OVERRIDDEN=1
+fi
+run_command "$COMMAND"

--- a/docker_volumes/manage.sh
+++ b/docker_volumes/manage.sh
@@ -1213,6 +1213,52 @@ status_dot() {
   fi
 }
 
+#Commands offered in the interactive menu, and the ones that don't take an app.
+MENU_COMMANDS="start stop restart update backup restore status logs version running system-update update-self doctor"
+NO_APP_COMMANDS="status running doctor system-update update-self"
+
+#Pick a command for the interactive menu. Sets PICKED_COMMAND ("" = reprompt,
+#"quit" = leave). With fzf you get arrow-key navigation and type-to-filter and
+#Esc to quit; otherwise a numbered menu that also accepts a typed command name.
+pick_command() {
+  PICKED_COMMAND=""
+  if command -v fzf >/dev/null 2>&1; then
+    # shellcheck disable=SC2086 # the command list is intentionally word-split
+    PICKED_COMMAND=$(printf '%s\n' $MENU_COMMANDS quit \
+      | fzf --prompt="DockerDance> " --reverse --height="~65%" \
+            --header="up/down move | type to filter | Enter select | Esc quit") \
+      || PICKED_COMMAND="quit"
+    return 0
+  fi
+  echo ""
+  echo "${bold}${cyan}DockerDance${normal} ${dim}v$VERSION${normal} - what would you like to do?"
+  echo "   1) start     2) stop      3) restart       4) update"
+  echo "   5) backup    6) restore   7) status        8) logs"
+  echo "   9) version  10) running  11) doctor       12) system-update"
+  echo "  13) update-self                             q) quit"
+  echo "  ${dim}tip: install fzf for arrow-key navigation and filtering${normal}"
+  printf "> "
+  read -r choice || { PICKED_COMMAND="quit"; return 0; }
+  case "$choice" in
+    1 ) PICKED_COMMAND="start" ;;
+    2 ) PICKED_COMMAND="stop" ;;
+    3 ) PICKED_COMMAND="restart" ;;
+    4 ) PICKED_COMMAND="update" ;;
+    5 ) PICKED_COMMAND="backup" ;;
+    6 ) PICKED_COMMAND="restore" ;;
+    7 ) PICKED_COMMAND="status" ;;
+    8 ) PICKED_COMMAND="logs" ;;
+    9 ) PICKED_COMMAND="version" ;;
+    10 ) PICKED_COMMAND="running" ;;
+    11 ) PICKED_COMMAND="doctor" ;;
+    12 ) PICKED_COMMAND="system-update" ;;
+    13 ) PICKED_COMMAND="update-self" ;;
+    q | Q | quit | exit ) PICKED_COMMAND="quit" ;;
+    start | stop | restart | update | backup | restore | status | logs | version | running | doctor | system-update | update-self ) PICKED_COMMAND="$choice" ;;
+    * ) echo "Not a valid choice." ;;
+  esac
+}
+
 pick_app() {
   #Sets PICKED_APPS to a space-separated list of chosen apps, or "" for all
   #apps. Returns 1 if the user cancelled or picked nothing valid.
@@ -1220,7 +1266,7 @@ pick_app() {
   if command -v fzf >/dev/null 2>&1; then
     #The preview pane shows live container status for the highlighted app
     fzf_preview='if [ {} = "all apps" ]; then docker ps; else (cd {} && '"$DOCKER_COMPOSE_COMMAND"' ps) 2>/dev/null || echo "(no status)"; fi'
-    pa_sel=$(printf '%s\n' "all apps" "$@" | fzf --multi --prompt="apps (TAB to multi-select)> " --preview "$fzf_preview") || return 1
+    pa_sel=$(printf '%s\n' "all apps" "$@" | fzf --multi --prompt="apps> " --header="TAB multi-select | Enter confirm | Esc to go back" --preview "$fzf_preview") || return 1
     #'all apps' anywhere in the selection means everything
     if printf '%s\n' "$pa_sel" | grep -qx "all apps"; then
       PICKED_APPS=""
@@ -1237,8 +1283,12 @@ pick_app() {
     n=$((n + 1))
     echo "  $n) $(status_dot "$app") $app"
   done
-  printf "Select app(s) [0-%s, space/comma separated]: " "$n"
+  echo "  b) back"
+  printf "Select app(s) [0-%s, space/comma separated, or b to go back]: " "$n"
   read -r selection || return 1
+  case "$selection" in
+    b | B | back ) return 1 ;;
+  esac
   selection=$(printf '%s' "$selection" | tr ',' ' ')
   pa_out=""
   # shellcheck disable=SC2086 # selection is an intentionally space-separated list
@@ -1276,38 +1326,23 @@ interactive() {
   maybe_discover_apps
   ALL_APPS=$Apps
   while :; do
-    echo ""
-    echo "${bold}${cyan}DockerDance${normal} ${dim}v$VERSION${normal} - what would you like to do?"
-    echo "  1) start    2) stop     3) restart"
-    echo "  4) update   5) backup   6) restore"
-    echo "  7) status   8) logs     9) version"
-    echo "  r) running  d) doctor   q) quit"
-    printf "> "
-    read -r choice || break
-    case "$choice" in
-      1 ) choice="start" ;;
-      2 ) choice="stop" ;;
-      3 ) choice="restart" ;;
-      4 ) choice="update" ;;
-      5 ) choice="backup" ;;
-      6 ) choice="restore" ;;
-      7 ) choice="status" ;;
-      8 ) choice="logs" ;;
-      9 ) choice="version" ;;
-      r | R | running ) choice="running" ;;
-      d | D | doctor ) choice="doctor" ;;
-      q | Q | quit | exit ) break ;;
-      * ) echo "Not a valid choice."; continue ;;
-    esac
+    pick_command
+    choice=$PICKED_COMMAND
+    [ -z "$choice" ] && continue
+    [ "$choice" = "quit" ] && break
     Apps=$ALL_APPS
-    #status/running/doctor act on everything (or nothing), so skip the picker
-    if [ "$choice" != "running" ] && [ "$choice" != "status" ] && [ "$choice" != "doctor" ]; then
-      # shellcheck disable=SC2086 # Apps is an intentionally space-separated list
-      pick_app $Apps || continue
-      if [ -n "$PICKED_APPS" ]; then
-        Apps=$PICKED_APPS
-      fi
-    fi
+    #Commands that act on everything (or nothing) skip the app picker; the rest
+    #let you pick app(s), where Esc (fzf) or 'b' (numbered) goes back to here.
+    case " $NO_APP_COMMANDS " in
+      *" $choice "* ) : ;;
+      * )
+        # shellcheck disable=SC2086 # Apps is an intentionally space-separated list
+        pick_app $Apps || continue
+        if [ -n "$PICKED_APPS" ]; then
+          Apps=$PICKED_APPS
+        fi
+        ;;
+    esac
     #Run in a subshell so one failed command reports and returns to the menu
     #instead of ending the whole session under set -e
     set +e

--- a/docker_volumes/manage.sh
+++ b/docker_volumes/manage.sh
@@ -15,24 +15,95 @@ DOCKER_VOLUMES="${DOCKER_VOLUMES:-/home/$USERNAME/docker_volumes/}"
 TARGET="${DOCKER_VOLUMES}backup/"
 
 
-#Add styling (only when writing to a terminal that supports it)
-bold="" normal=""
-if [ -t 1 ] && [ -n "${TERM:-}" ] && [ "${TERM:-}" != "dumb" ] && command -v tput >/dev/null 2>&1; then
-  bold=$(tput bold) || bold=""
-  normal=$(tput sgr0) || normal=""
+#Add styling (only on a terminal that supports it; NO_COLOR=1 disables colour, see no-color.org)
+bold="" normal="" red="" green="" yellow="" cyan="" dim=""
+SPINNER=""
+if [ -t 1 ] && [ -n "${TERM:-}" ] && [ "${TERM:-}" != "dumb" ]; then
+  SPINNER=1
+  if [ -z "${NO_COLOR:-}" ] && command -v tput >/dev/null 2>&1; then
+    bold=$(tput bold) || bold=""
+    normal=$(tput sgr0) || normal=""
+    if [ "$(tput colors 2>/dev/null || echo 0)" -ge 8 ]; then
+      red=$(tput setaf 1) || red=""
+      green=$(tput setaf 2) || green=""
+      yellow=$(tput setaf 3) || yellow=""
+      cyan=$(tput setaf 6) || cyan=""
+      dim=$(tput dim 2>/dev/null) || dim=""
+    fi
+  fi
 fi
 
+#Unicode niceties with a plain-ASCII fallback for non UTF-8 locales
+case "${LC_ALL:-${LC_CTYPE:-${LANG:-}}}" in
+  *[Uu][Tt][Ff]-8* | *[Uu][Tt][Ff]8* )
+    SPINNER_FRAMES='⠋ ⠙ ⠹ ⠸ ⠼ ⠴ ⠦ ⠧ ⠇ ⠏'
+    ARROW='⇒'
+    ;;
+  * )
+    SPINNER_FRAMES='- \ | /'
+    ARROW='=>'
+    ;;
+esac
+
+STEP_LOG="${TMPDIR:-/tmp}/dockerdance-step.$$.log"
+cleanup() {
+  tput cnorm 2>/dev/null || true
+  rm -f "$STEP_LOG"
+}
+trap cleanup EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
 actioninfo() {
-  echo "${bold}[action]:${normal} ⇒ $1"
+  echo "${bold}${cyan}[action]${normal} $ARROW $1"
 }
 ok() {
-  echo "${bold}[ok]${normal} - $1"
+  echo "${bold}${green}[ok]${normal} - $1"
 }
 success() {
-  echo "${bold}[success]${normal} - $1"
+  echo "${bold}${green}[success]${normal} - $1"
+}
+warn() {
+  echo "${bold}${yellow}[warn]${normal} - $1" >&2
 }
 error() {
-  echo "${bold}[error]${normal} - $1" >&2
+  echo "${bold}${red}[error]${normal} - $1" >&2
+}
+
+#Run a command behind a spinner. Output is captured and only shown if the command fails.
+#Without a terminal (cron, pipes) the label is printed and the command runs with plain output.
+run_step() {
+  step_label=$1
+  shift
+  if [ -z "$SPINNER" ]; then
+    echo "$step_label"
+    "$@"
+    return 0
+  fi
+  "$@" >"$STEP_LOG" 2>&1 &
+  step_pid=$!
+  tput civis 2>/dev/null || true
+  step_status=0
+  while kill -0 "$step_pid" 2>/dev/null; do
+    # shellcheck disable=SC2086 # frames are an intentionally space-separated list
+    for frame in $SPINNER_FRAMES; do
+      kill -0 "$step_pid" 2>/dev/null || break
+      printf '\r%s%s%s %s' "$cyan" "$frame" "$normal" "$step_label"
+      sleep 0.1 2>/dev/null || sleep 1
+    done
+  done
+  wait "$step_pid" || step_status=$?
+  printf '\r'
+  tput el 2>/dev/null || printf '%-79s\r' ''
+  tput cnorm 2>/dev/null || true
+  if [ "$step_status" -ne 0 ]; then
+    error "$step_label failed:"
+    sed 's/^/    /' "$STEP_LOG" >&2
+    rm -f "$STEP_LOG"
+    return "$step_status"
+  fi
+  rm -f "$STEP_LOG"
+  return 0
 }
 
 #Check Docker is installed, the daemon is reachable and compose is available
@@ -82,73 +153,80 @@ enter_app() {
   cd "$1"
 }
 
+#Progress counter shown when more than one app is being processed
+APP_NUM="" APP_TOTAL=""
+counter() {
+  if [ -n "$APP_TOTAL" ] && [ "$APP_TOTAL" -gt 1 ]; then
+    printf '%s[%s/%s]%s ' "$dim" "$APP_NUM" "$APP_TOTAL" "$normal"
+  fi
+}
+
+RUN_START=""
+elapsed() {
+  [ -z "$RUN_START" ] && return 0
+  e=$(( $(date +%s) - RUN_START ))
+  if [ "$e" -ge 60 ]; then
+    printf '%dm %ds' $((e / 60)) $((e % 60))
+  else
+    printf '%ds' "$e"
+  fi
+}
+
 list_apps() {
   for app in "$@"; do
-    echo "⇒ $app"
+    echo "$cyan$ARROW$normal $app"
   done
   echo "---"
 }
 
 start_app() {
-  echo "Starting ${bold}$1${normal}"
   enter_app "$1"
-  compose up -d
-  ok "$1 started"
+  run_step "$(counter)Starting ${bold}$1${normal}" compose up -d
+  ok "$(counter)$1 started"
   cd ..
 }
 
 stop_app() {
-  echo "Stopping ${bold}$1${normal}"
   enter_app "$1"
   #stop (not kill) shuts containers down gracefully so databases can finish writing
-  compose stop
-  ok "$1 stopped"
+  run_step "$(counter)Stopping ${bold}$1${normal}" compose stop
+  ok "$(counter)$1 stopped"
   cd ..
 }
 
 restart_app() {
-  echo "Restarting ${bold}$1${normal}"
   enter_app "$1"
-  compose stop
-  ok "$1 stopped"
-  compose up -d
-  ok "$1 restarted"
+  run_step "$(counter)Stopping ${bold}$1${normal}" compose stop
+  run_step "$(counter)Starting ${bold}$1${normal}" compose up -d
+  ok "$(counter)$1 restarted"
   cd ..
 }
 
 update_app() {
-  echo "Stopping ${bold}$1${normal}"
   enter_app "$1"
-  compose stop
-  ok "$1 stopped"
-  echo "Updating $1"
+  run_step "$(counter)Stopping ${bold}$1${normal}" compose stop
+  echo "$(counter)Pulling ${bold}$1${normal} images"
   compose pull
-  ok "Images up to date. Starting all services."
-  compose up -d
-  ok "$1 updated and running"
+  run_step "$(counter)Starting ${bold}$1${normal}" compose up -d
+  ok "$(counter)$1 updated and running"
   cd ..
 }
 
 backup_app() {
-  echo "Stopping ${bold}$1${normal}"
   enter_app "$1"
-  compose stop
-  ok "$1 stopped"
-  echo "Backing up $1"
+  run_step "$(counter)Stopping ${bold}$1${normal}" compose stop
   mkdir -p "$TARGET"
-  tar -cjf "${TARGET}${1}$(date '+%Y-%m-%d').tar.bz2" "${DOCKER_VOLUMES}${1}"
-  ok "$1 is backed up"
-  echo "Updating $1"
+  run_step "$(counter)Backing up ${bold}$1${normal}" tar -cjf "${TARGET}${1}$(date '+%Y-%m-%d').tar.bz2" "${DOCKER_VOLUMES}${1}"
+  echo "$(counter)Pulling ${bold}$1${normal} images"
   compose pull
-  ok "Images up to date. Starting all services."
-  compose up -d
-  ok "$1 backed up, updated and running"
+  run_step "$(counter)Starting ${bold}$1${normal}" compose up -d
+  ok "$(counter)$1 backed up, updated and running"
   cd ..
 }
 
 usage() {
   cat <<EOF
-${bold}DockerDance${normal} - bulk manage docker compose apps
+${bold}${cyan}DockerDance${normal} - bulk manage docker compose apps
 
 Usage: ./manage.sh <command> [app ...]
 
@@ -173,6 +251,9 @@ run_command() {
   menu_command=$1
   # shellcheck disable=SC2086 # Apps is an intentionally space-separated list
   set -- $Apps
+  RUN_START=$(date +%s)
+  APP_TOTAL=$#
+  APP_NUM=0
   case "$menu_command" in
     'backup' )
       checkDefault
@@ -180,9 +261,10 @@ run_command() {
       actioninfo "${bold}Backing up${normal} apps including:"
       list_apps "$@"
       for app in "$@"; do
+        APP_NUM=$((APP_NUM + 1))
         backup_app "$app"
       done
-      success "Backing up completed"
+      success "Backing up completed in $(elapsed)"
       ;;
     'restore' )
       echo "Coming soon:"
@@ -210,9 +292,10 @@ run_command() {
       actioninfo "${bold}Updating all services.${normal}"
       list_apps "$@"
       for app in "$@"; do
+        APP_NUM=$((APP_NUM + 1))
         update_app "$app"
       done
-      success "Services updated. Give them a moment to warm up."
+      success "Services updated in $(elapsed). Give them a moment to warm up."
       ;;
     'stop' )
       checkDefault
@@ -220,9 +303,10 @@ run_command() {
       actioninfo "${bold}Stopping${normal} all services:"
       list_apps "$@"
       for app in "$@"; do
+        APP_NUM=$((APP_NUM + 1))
         stop_app "$app"
       done
-      success "Services stopped"
+      success "Services stopped in $(elapsed)"
       ;;
     'start' )
       checkDefault
@@ -230,18 +314,20 @@ run_command() {
       actioninfo "${bold}Starting${normal} all services"
       list_apps "$@"
       for app in "$@"; do
+        APP_NUM=$((APP_NUM + 1))
         start_app "$app"
       done
-      success "Services started. Give them a moment to warm up."
+      success "Services started in $(elapsed). Give them a moment to warm up."
       ;;
     'restart' )
       checkDefault
       require_docker
       actioninfo "${bold}Restarting${normal} all services"
       for app in "$@"; do
+        APP_NUM=$((APP_NUM + 1))
         restart_app "$app"
       done
-      success "Services restarted. Give them a moment to warm up."
+      success "Services restarted in $(elapsed). Give them a moment to warm up."
       ;;
     'version' )
       checkDefault
@@ -317,7 +403,7 @@ interactive() {
   ALL_APPS=$Apps
   while :; do
     echo ""
-    echo "${bold}DockerDance${normal} - what would you like to do?"
+    echo "${bold}${cyan}DockerDance${normal} - what would you like to do?"
     echo "  1) start    2) stop     3) restart"
     echo "  4) update   5) backup   6) logs"
     echo "  7) version  8) running  q) quit"

--- a/docker_volumes/manage.sh
+++ b/docker_volumes/manage.sh
@@ -1178,14 +1178,19 @@ status_dot() {
 }
 
 pick_app() {
-  #Sets PICKED_APP to one app name, or "" for all apps. Returns 1 if cancelled.
-  PICKED_APP=""
+  #Sets PICKED_APPS to a space-separated list of chosen apps, or "" for all
+  #apps. Returns 1 if the user cancelled or picked nothing valid.
+  PICKED_APPS=""
   if command -v fzf >/dev/null 2>&1; then
     #The preview pane shows live container status for the highlighted app
     fzf_preview='if [ {} = "all apps" ]; then docker ps; else (cd {} && '"$DOCKER_COMPOSE_COMMAND"' ps) 2>/dev/null || echo "(no status)"; fi'
-    PICKED_APP=$(printf '%s\n' "all apps" "$@" | fzf --prompt="app> " --preview "$fzf_preview") || return 1
-    if [ "$PICKED_APP" = "all apps" ]; then
-      PICKED_APP=""
+    pa_sel=$(printf '%s\n' "all apps" "$@" | fzf --multi --prompt="apps (TAB to multi-select)> " --preview "$fzf_preview") || return 1
+    #'all apps' anywhere in the selection means everything
+    if printf '%s\n' "$pa_sel" | grep -qx "all apps"; then
+      PICKED_APPS=""
+    else
+      PICKED_APPS=$(printf '%s' "$pa_sel" | tr '\n' ' ')
+      PICKED_APPS=${PICKED_APPS% }
     fi
     return 0
   fi
@@ -1196,21 +1201,37 @@ pick_app() {
     n=$((n + 1))
     echo "  $n) $(status_dot "$app") $app"
   done
-  printf "Select an app [0-%s]: " "$n"
+  printf "Select app(s) [0-%s, space/comma separated]: " "$n"
   read -r selection || return 1
-  if [ "$selection" = "0" ]; then
-    return 0
-  fi
-  n=0
-  for app in "$@"; do
-    n=$((n + 1))
-    if [ "$n" = "$selection" ]; then
-      PICKED_APP=$app
+  selection=$(printf '%s' "$selection" | tr ',' ' ')
+  pa_out=""
+  # shellcheck disable=SC2086 # selection is an intentionally space-separated list
+  for sel in $selection; do
+    if [ "$sel" = "0" ]; then
+      PICKED_APPS=""
       return 0
     fi
+    n=0
+    hit=""
+    for app in "$@"; do
+      n=$((n + 1))
+      if [ "$n" = "$sel" ]; then
+        hit=$app
+        break
+      fi
+    done
+    if [ -z "$hit" ]; then
+      echo "Not a valid selection: $sel"
+      return 1
+    fi
+    pa_out="$pa_out $hit"
   done
-  echo "Not a valid selection."
-  return 1
+  if [ -z "$pa_out" ]; then
+    echo "Nothing selected."
+    return 1
+  fi
+  PICKED_APPS=${pa_out# }
+  return 0
 }
 
 interactive() {
@@ -1247,8 +1268,8 @@ interactive() {
     if [ "$choice" != "running" ] && [ "$choice" != "status" ] && [ "$choice" != "doctor" ]; then
       # shellcheck disable=SC2086 # Apps is an intentionally space-separated list
       pick_app $Apps || continue
-      if [ -n "$PICKED_APP" ]; then
-        Apps=$PICKED_APP
+      if [ -n "$PICKED_APPS" ]; then
+        Apps=$PICKED_APPS
       fi
     fi
     #Run in a subshell so one failed command reports and returns to the menu

--- a/docker_volumes/manage.sh
+++ b/docker_volumes/manage.sh
@@ -67,7 +67,9 @@ case "$SPINNER_FRAMES" in
   * )  DOT_ON='*' DOT_OFF='-' ;;
 esac
 
-STEP_LOG="${TMPDIR:-/tmp}/dockerdance-step.$$.log"
+#mktemp gives an unpredictable, owner-only name so another user can't pre-create
+#it as a symlink and have root truncate a file through us. Fall back to the PID.
+STEP_LOG=$(mktemp "${TMPDIR:-/tmp}/dockerdance-step.XXXXXX" 2>/dev/null) || STEP_LOG="${TMPDIR:-/tmp}/dockerdance-step.$$.log"
 #One state-changing run at a time per docker_volumes folder (protects
 #against a cron backup overlapping a manual update)
 LOCK_DIR="${TMPDIR:-/tmp}/dockerdance$(pwd | tr '/ ' '__').lock"
@@ -403,8 +405,18 @@ backup_app() {
   leave_app
 }
 
+tar_is_busybox() {
+  case "$(tar --version 2>&1 | head -1)" in
+    *[Bb]usy[Bb]ox* ) return 0 ;;
+    * ) return 1 ;;
+  esac
+}
+
 #Restore the newest backup for an app (issue #2). Current data is moved
 #aside - never deleted - so a bad restore is always reversible by hand.
+#Archives are treated as untrusted: extraction happens into an isolated
+#staging dir (never straight onto the filesystem root), every member is
+#checked for path-traversal, and only the '<app>/' subtree is promoted.
 restore_app() {
   app_start=$(date +%s)
   # shellcheck disable=SC2012 # archive names are script-generated (no spaces/newlines)
@@ -413,16 +425,50 @@ restore_app() {
     error "No backups found for '$1' in $TARGET"
     exit 1
   fi
-  #Which layout is inside? New backups hold '<app>/...', pre-v0.2.0 ones held absolute paths
+  #Which layout is inside? New backups hold '<app>/...'; pre-v0.2.0 ones held
+  #absolute paths like '/home/x/docker_volumes/<app>/...'. Work out how many
+  #leading components to strip so the app folder lands at the top of staging.
   first_member=$(tar -tjf "$archive" 2>/dev/null | head -1)
-  case "$first_member" in
-    "$1"/* ) restore_root=$DOCKER_VOLUMES ;;
-    *docker_volumes/"$1"/* ) restore_root="/" ;;
+  first_rel=${first_member#/}
+  case "$first_rel" in
+    "$1"/* )
+      strip_count=0 ; layout="relative" ;;
+    */"$1"/* )
+      legacy_prefix=${first_rel%%/"$1"/*}
+      strip_count=$(printf '%s\n' "$legacy_prefix" | awk -F/ '{print NF}')
+      layout="legacy" ;;
     * )
       error "Unrecognised layout in ${archive##*/} - restore it manually with tar."
-      exit 1
-      ;;
+      exit 1 ;;
   esac
+  #Legacy absolute archives rely on GNU/bsdtar stripping the leading '/';
+  #busybox tar does not, so refuse that one combination rather than risk a
+  #write outside the staging dir.
+  if [ "$layout" = "legacy" ] && tar_is_busybox; then
+    error "${archive##*/} is a legacy absolute-path backup and your tar is busybox, which can't extract it safely. Restore it on a host with GNU tar."
+    exit 1
+  fi
+  #Reject any member with a '..' component (all layouts) or an absolute path
+  #(relative layout only - legacy members are absolute by design and stripped).
+  member_list=$(mktemp "${TMPDIR:-/tmp}/dockerdance-members.XXXXXX" 2>/dev/null) || member_list="${TMPDIR:-/tmp}/dockerdance-members.$$"
+  tar -tjf "$archive" 2>/dev/null > "$member_list"
+  bad_member=""
+  while IFS= read -r m; do
+    case "/$m/" in
+      */../* ) bad_member=$m; break ;;
+    esac
+    if [ "$layout" = "relative" ]; then
+      case "$m" in
+        /* ) bad_member=$m; break ;;
+      esac
+    fi
+  done < "$member_list"
+  rm -f "$member_list"
+  if [ -n "$bad_member" ]; then
+    error "Refusing to restore ${archive##*/}: unsafe path in archive ('$bad_member')."
+    exit 1
+  fi
+
   echo "$(counter)Restoring ${bold}$1${normal} from ${archive##*/}"
   if [ -t 0 ]; then
     printf '%s' "This replaces ${DOCKER_VOLUMES}${1} (current data is set aside, not deleted). Continue? [y/N] "
@@ -435,17 +481,33 @@ restore_app() {
     error "restore needs a terminal to confirm. Run it interactively."
     exit 1
   fi
+
   enter_app "$1"
   run_step "$(counter)Stopping ${bold}$1${normal}" compose stop -t "$STOP_TIMEOUT"
   leave_app
+
+  #Stage under backup/ (same filesystem as the app folders, so the promote is
+  #an atomic rename) and extract there - never onto the host root.
+  mkdir -p "$TARGET"
+  staging=$(mktemp -d "${TARGET}restore.XXXXXX") || { error "Couldn't create a staging dir in $TARGET"; exit 1; }
   aside="${DOCKER_VOLUMES}${1}.pre-restore.$(date '+%Y%m%d%H%M%S')"
   mv "${DOCKER_VOLUMES}${1}" "$aside"
-  if ! run_step "$(counter)Extracting ${bold}${archive##*/}${normal}" tar -xjf "$archive" -C "$restore_root"; then
-    rm -rf "${DOCKER_VOLUMES:?}${1}"
-    mv "$aside" "${DOCKER_VOLUMES}${1}"
+  extract_ok=1
+  if [ "$strip_count" -gt 0 ]; then
+    run_step "$(counter)Extracting ${bold}${archive##*/}${normal}" tar -xjf "$archive" -C "$staging" --strip-components="$strip_count" || extract_ok=0
+  else
+    run_step "$(counter)Extracting ${bold}${archive##*/}${normal}" tar -xjf "$archive" -C "$staging" || extract_ok=0
+  fi
+  [ -d "$staging/$1" ] || extract_ok=0
+  if [ "$extract_ok" -ne 1 ]; then
+    rm -rf "$staging"
+    [ -e "${DOCKER_VOLUMES}${1}" ] || mv "$aside" "${DOCKER_VOLUMES}${1}"
     error "Restore failed - the original data was put back."
     exit 1
   fi
+  mv "$staging/$1" "${DOCKER_VOLUMES}${1}"
+  rm -rf "$staging"
+
   enter_app "$1"
   run_step "$(counter)Starting ${bold}$1${normal}" compose up -d
   leave_app

--- a/docker_volumes/manage.sh
+++ b/docker_volumes/manage.sh
@@ -182,11 +182,47 @@ acquire_lock() {
   HAVE_LOCK=1
 }
 
+#Docker's official install ("convenience") script. Only ever fetched from here.
+DOCKER_INSTALL_URL="https://get.docker.com"
+
+#Docker isn't installed: point at the official docs, and - only interactively,
+#never in cron - offer to fetch and run Docker's official install script. The
+#script uses sudo itself where it needs root. Defaults to no.
+offer_docker_install() {
+  echo "  Install Docker for your platform: https://docs.docker.com/engine/install/"
+  echo "  Or use Docker's official script (review it first; it needs root):"
+  echo "    curl -fsSL $DOCKER_INSTALL_URL -o get-docker.sh && sh get-docker.sh"
+  #Never auto-install: needs a terminal and a downloader, and dry-run just shows the hint
+  [ -n "${DRY_RUN:-}" ] && return 0
+  [ -t 0 ] || return 0
+  command -v curl >/dev/null 2>&1 || command -v wget >/dev/null 2>&1 || return 0
+  printf 'Download and run the official Docker install script now? [y/N] '
+  read -r odi_ans || odi_ans=""
+  case "$odi_ans" in
+    y | Y | yes | YES ) ;;
+    * ) return 0 ;;
+  esac
+  odi_dir=$(mktemp -d "${TMPDIR:-/tmp}/dockerdance-getdocker.XXXXXX" 2>/dev/null) || { odi_dir="${TMPDIR:-/tmp}/dockerdance-getdocker.$$"; mkdir -p "$odi_dir"; }
+  echo "Downloading $DOCKER_INSTALL_URL ..."
+  if fetch_url "$DOCKER_INSTALL_URL" >"$odi_dir/get-docker.sh" && [ -s "$odi_dir/get-docker.sh" ]; then
+    echo "Running the installer (you may be prompted for a sudo password)..."
+    if sh "$odi_dir/get-docker.sh"; then
+      success "Docker installed. You may need to log out and back in for group membership to apply, then re-run this command."
+    else
+      error "The Docker install script exited with an error - see its output above."
+    fi
+  else
+    error "Couldn't download the Docker install script from $DOCKER_INSTALL_URL."
+  fi
+  rm -rf "$odi_dir"
+}
+
 #Check Docker is installed, the daemon is reachable and compose is available
 DOCKER_COMPOSE_COMMAND=""
 require_docker() {
   if ! command -v docker >/dev/null 2>&1; then
-    error "Please install Docker before proceeding."
+    error "Docker isn't installed (or isn't in your PATH)."
+    offer_docker_install
     exit 1
   fi
   if ! docker info >/dev/null 2>&1; then
@@ -841,7 +877,7 @@ run_doctor() {
       dbad "Docker is installed but the daemon isn't reachable (start it, or add your user to the docker group)"
     fi
   else
-    dbad "Docker not found in PATH"
+    dbad "Docker not found in PATH - install it from $DOCKER_INSTALL_URL (any app command will also offer to run the installer)"
   fi
   if docker compose version >/dev/null 2>&1; then
     dok "Compose plugin: docker compose ($(docker compose version --short 2>/dev/null))"

--- a/docker_volumes/manage.sh
+++ b/docker_volumes/manage.sh
@@ -299,6 +299,29 @@ leave_app() {
   cd "$APP_RETURN_DIR"
 }
 
+#Silent version of enter_app's lookup: echo the folder that holds the compose
+#file for app $1 (itself, or one unambiguous level down), or fail quietly.
+resolve_dir() {
+  if has_compose_file "$1"; then
+    echo "$1"
+    return 0
+  fi
+  rd_hit=""
+  rd_n=0
+  for rd in "$1"/*/; do
+    [ -d "$rd" ] || continue
+    if has_compose_file "$rd"; then
+      rd_hit=${rd%/}
+      rd_n=$((rd_n + 1))
+    fi
+  done
+  if [ "$rd_n" -eq 1 ]; then
+    echo "$rd_hit"
+    return 0
+  fi
+  return 1
+}
+
 #Is $1 one of the space-separated words in $2?
 in_list() {
   # shellcheck disable=SC2086 # $2 is an intentionally space-separated list
@@ -740,6 +763,153 @@ system_update() {
   success "System updated with $pm"
 }
 
+#One dashboard row per app: a coloured up/stopped dot, container state,
+#primary image and health. Read-only, and resilient to missing folders.
+status_row() {
+  sr_app=$1
+  sr_dir=$(resolve_dir "$sr_app") || sr_dir=""
+  sr_dot="$dim$DOT_OFF$normal"
+  sr_state="stopped"
+  sr_img="-"
+  sr_health="-"
+  if [ -z "$sr_dir" ]; then
+    printf '%s %-18s %-9s %-30s %s\n' "$dim?$normal" "$sr_app" "?" "(no compose file)" "-"
+    return 0
+  fi
+  sr_ids=$(cd "$sr_dir" && compose ps -q 2>/dev/null)
+  if [ -n "$sr_ids" ]; then
+    sr_total=0; sr_up=0; sr_unhealthy=0; sr_starting=0; sr_hchecks=0
+    # shellcheck disable=SC2086 # ids are one-per-line without spaces
+    for sr_id in $sr_ids; do
+      sr_total=$((sr_total + 1))
+      [ "$(docker inspect -f '{{.State.Status}}' "$sr_id" 2>/dev/null)" = "running" ] && sr_up=$((sr_up + 1))
+      sr_h=$(docker inspect -f '{{if .State.Health}}{{.State.Health.Status}}{{end}}' "$sr_id" 2>/dev/null)
+      case "$sr_h" in
+        healthy )   sr_hchecks=$((sr_hchecks + 1)) ;;
+        unhealthy ) sr_hchecks=$((sr_hchecks + 1)); sr_unhealthy=$((sr_unhealthy + 1)) ;;
+        starting )  sr_hchecks=$((sr_hchecks + 1)); sr_starting=$((sr_starting + 1)) ;;
+      esac
+      [ "$sr_img" = "-" ] && sr_img=$(docker inspect -f '{{.Config.Image}}' "$sr_id" 2>/dev/null)
+    done
+    if [ "$sr_up" -eq 0 ]; then
+      sr_state="stopped"; sr_dot="$dim$DOT_OFF$normal"
+    elif [ "$sr_up" -eq "$sr_total" ]; then
+      sr_state="up"; sr_dot="$green$DOT_ON$normal"
+    else
+      sr_state="$sr_up/$sr_total up"; sr_dot="$yellow$DOT_ON$normal"
+    fi
+    if [ "$sr_unhealthy" -gt 0 ]; then
+      sr_health="${red}unhealthy${normal}"
+    elif [ "$sr_starting" -gt 0 ]; then
+      sr_health="${yellow}starting${normal}"
+    elif [ "$sr_hchecks" -gt 0 ]; then
+      sr_health="${green}healthy${normal}"
+    fi
+  fi
+  [ -z "$sr_img" ] && sr_img="-"
+  sr_img=${sr_img%%,*}
+  if [ "${#sr_img}" -gt 30 ]; then
+    sr_img="$(printf '%.27s' "$sr_img")..."
+  fi
+  #dot (leading) and health (trailing) carry the only colour, so the padded
+  #plain columns in between still line up.
+  printf '%s %-18s %-9s %-30s %s\n' "$sr_dot" "$sr_app" "$sr_state" "$sr_img" "$sr_health"
+}
+
+show_status() {
+  echo "${bold}${cyan}DockerDance${normal} status - $(pwd)"
+  printf '  %-18s %-9s %-30s %s\n' "APP" "STATE" "IMAGE" "HEALTH"
+  for ss_app in "$@"; do
+    status_row "$ss_app"
+  done
+}
+
+#Diagnostics: check the environment and configuration without changing anything.
+run_doctor() {
+  dok()   { echo "  ${green}[ok]${normal}   $1"; }
+  dwarn() { echo "  ${yellow}[warn]${normal} $1"; }
+  dbad()  { echo "  ${red}[FAIL]${normal} $1"; }
+  echo "${bold}${cyan}DockerDance doctor${normal} - v$VERSION"
+  echo "  script:      $0"
+  echo "  working dir: $(pwd)"
+  echo "  OS:          $(uname -s) $(uname -r)"
+  echo "---"
+  if command -v docker >/dev/null 2>&1; then
+    if docker info >/dev/null 2>&1; then
+      dok "Docker daemon reachable ($(docker --version 2>/dev/null))"
+    else
+      dbad "Docker is installed but the daemon isn't reachable (start it, or add your user to the docker group)"
+    fi
+  else
+    dbad "Docker not found in PATH"
+  fi
+  if docker compose version >/dev/null 2>&1; then
+    dok "Compose plugin: docker compose ($(docker compose version --short 2>/dev/null))"
+  elif command -v docker-compose >/dev/null 2>&1; then
+    dwarn "Using legacy docker-compose ($(docker-compose version --short 2>/dev/null))"
+  else
+    dbad "No 'docker compose' plugin or 'docker-compose' found"
+  fi
+  if command -v curl >/dev/null 2>&1 || command -v wget >/dev/null 2>&1; then
+    dok "curl/wget present (needed for update-self and NOTIFY_WEBHOOK)"
+  else
+    dwarn "Neither curl nor wget found - update-self and webhooks won't work"
+  fi
+  if command -v fzf >/dev/null 2>&1; then
+    dok "fzf present (fuzzy app picker in the menu)"
+  else
+    dwarn "fzf not found - the menu falls back to a numbered list"
+  fi
+  dr_pm=""
+  for dr_c in apt-get dnf yum pacman zypper apk brew; do
+    command -v "$dr_c" >/dev/null 2>&1 && { dr_pm=$dr_c; break; }
+  done
+  if [ -n "$dr_pm" ]; then
+    dok "Package manager for system-update: $dr_pm"
+  else
+    dwarn "No supported package manager found for system-update"
+  fi
+  if tar_is_busybox; then
+    dwarn "tar is busybox - legacy absolute-path backups can't be restored on this host"
+  else
+    dok "tar supports safe extraction"
+  fi
+  if [ -d "$DOCKER_VOLUMES" ]; then
+    if [ -w "$DOCKER_VOLUMES" ]; then
+      dok "DOCKER_VOLUMES writable: $DOCKER_VOLUMES"
+    else
+      dwarn "DOCKER_VOLUMES not writable by this user: $DOCKER_VOLUMES"
+    fi
+  else
+    dwarn "DOCKER_VOLUMES does not exist: $DOCKER_VOLUMES"
+  fi
+  if [ -f "./manage.conf" ]; then
+    dok "manage.conf found and loaded"
+  else
+    echo "  manage.conf: not present (using script defaults / environment)"
+  fi
+  if [ -d "$LOCK_DIR" ]; then
+    dwarn "A run lock exists ($LOCK_DIR) - another run is active, or it's stale (remove it if so)"
+  else
+    dok "No stale run lock"
+  fi
+  echo "---"
+  echo "  settings: STOP_TIMEOUT=$STOP_TIMEOUT  HEALTH_TIMEOUT=$HEALTH_TIMEOUT  PARALLEL_PULLS=$PARALLEL_PULLS  BACKUP_KEEP=${BACKUP_KEEP:-unset}  NOTIFY_WEBHOOK=$([ -n "${NOTIFY_WEBHOOK:-}" ] && echo set || echo unset)"
+  if [ "$Apps" = "auto" ] || [ -z "$Apps" ]; then
+    dr_saved=$Apps
+    discover_apps
+    dr_found=$Apps
+    Apps=$dr_saved
+    if [ -n "$dr_found" ]; then
+      dok "Apps=auto discovers:$dr_found"
+    else
+      dwarn "Apps=auto found no folders with a compose file here"
+    fi
+  else
+    echo "  Apps (pinned): $Apps"
+  fi
+}
+
 fetch_url() {
   if command -v curl >/dev/null 2>&1; then
     curl -fsSL "$1"
@@ -802,9 +972,11 @@ Commands:
   update       Pull the latest images, then restart apps on them
   backup       Pull, stop, tar app folders into the backup folder, then start again
   restore      Put the newest backup archive back in place (current data is set aside)
+  status       Dashboard: each app's state, image and health at a glance
   logs         Show recent logs (follows the log when a single app is targeted)
   version      Show the image versions each app is using
   running      List running containers (docker ps)
+  doctor       Check the environment and configuration (read-only)
   system-update  Update the host OS packages (detects apt/dnf/yum/pacman/zypper/apk/brew; 'apt' still works as an alias)
   update-self  Update this script to the latest GitHub release
   help         Show this help (--version shows the script version)
@@ -823,7 +995,7 @@ EOF
 run_command() {
   menu_command=$1
   case "$menu_command" in
-    'backup' | 'restore' | 'update' | 'stop' | 'start' | 'restart' | 'logs' | 'version' ) maybe_discover_apps ;;
+    'backup' | 'restore' | 'update' | 'stop' | 'start' | 'restart' | 'logs' | 'version' | 'status' ) maybe_discover_apps ;;
   esac
   # shellcheck disable=SC2086 # Apps is an intentionally space-separated list
   set -- $Apps
@@ -961,6 +1133,14 @@ run_command() {
         leave_app
       done
       ;;
+    'status' )
+      checkDefault
+      require_docker
+      show_status "$@"
+      ;;
+    'doctor' )
+      run_doctor
+      ;;
     'running' )
       require_docker
       echo "Getting all running services"
@@ -1043,8 +1223,8 @@ interactive() {
     echo "${bold}${cyan}DockerDance${normal} ${dim}v$VERSION${normal} - what would you like to do?"
     echo "  1) start    2) stop     3) restart"
     echo "  4) update   5) backup   6) restore"
-    echo "  7) logs     8) version  9) running"
-    echo "  q) quit"
+    echo "  7) status   8) logs     9) version"
+    echo "  r) running  d) doctor   q) quit"
     printf "> "
     read -r choice || break
     case "$choice" in
@@ -1054,14 +1234,17 @@ interactive() {
       4 ) choice="update" ;;
       5 ) choice="backup" ;;
       6 ) choice="restore" ;;
-      7 ) choice="logs" ;;
-      8 ) choice="version" ;;
-      9 ) choice="running" ;;
+      7 ) choice="status" ;;
+      8 ) choice="logs" ;;
+      9 ) choice="version" ;;
+      r | R | running ) choice="running" ;;
+      d | D | doctor ) choice="doctor" ;;
       q | Q | quit | exit ) break ;;
       * ) echo "Not a valid choice."; continue ;;
     esac
     Apps=$ALL_APPS
-    if [ "$choice" != "running" ]; then
+    #status/running/doctor act on everything (or nothing), so skip the picker
+    if [ "$choice" != "running" ] && [ "$choice" != "status" ] && [ "$choice" != "doctor" ]; then
       # shellcheck disable=SC2086 # Apps is an intentionally space-separated list
       pick_app $Apps || continue
       if [ -n "$PICKED_APP" ]; then

--- a/docker_volumes/manage.sh
+++ b/docker_volumes/manage.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -e
 
-VERSION="0.2.0"
+VERSION="0.3.0"
 #Repo used by update-self; override with DOCKERDANCE_REPO=owner/name
 SELF_REPO="${DOCKERDANCE_REPO:-AdamXweb/DockerDance}"
 
@@ -630,8 +630,8 @@ restore_app() {
     error "No backups found for '$1' in $TARGET"
     exit 1
   fi
-  #Which layout is inside? New backups hold '<app>/...'; pre-v0.2.0 ones held
-  #absolute paths like '/home/x/docker_volumes/<app>/...'. Work out how many
+  #Which layout is inside? New backups hold '<app>/...'; older (v0.1.0-era)
+  #ones held absolute paths like '/home/x/docker_volumes/<app>/...'. Work out how many
   #leading components to strip so the app folder lands at the top of staging.
   first_member=$(tar -tjf "$archive" 2>/dev/null | head -1)
   first_rel=${first_member#/}

--- a/docker_volumes/manage.sh
+++ b/docker_volumes/manage.sh
@@ -412,6 +412,41 @@ restore_app() {
   record "$1" "restored"
 }
 
+#Update the host OS packages with whatever package manager is present.
+#Checked in order; the first hit wins, so distro managers beat homebrew.
+system_update() {
+  pm=""
+  for candidate in apt-get dnf yum pacman zypper apk brew; do
+    if command -v "$candidate" >/dev/null 2>&1; then
+      pm=$candidate
+      break
+    fi
+  done
+  if [ -z "$pm" ]; then
+    error "No supported package manager found (apt-get, dnf, yum, pacman, zypper, apk or brew)."
+    exit 1
+  fi
+  if [ "$pm" != "brew" ] && [ "$(id -u)" -ne 0 ]; then
+    error "System updates with $pm need root. Try: sudo ./manage.sh system-update"
+    exit 1
+  fi
+  if [ "$pm" = "brew" ] && [ "$(id -u)" -eq 0 ]; then
+    error "Homebrew refuses to run as root. Run this as your normal user."
+    exit 1
+  fi
+  actioninfo "Updating the system with ${bold}$pm${normal}"
+  case "$pm" in
+    apt-get ) apt-get update && apt-get upgrade -y ;;
+    dnf )     dnf upgrade --refresh -y ;;
+    yum )     yum update -y ;;
+    pacman )  pacman -Syu --noconfirm ;;
+    zypper )  zypper --non-interactive refresh && zypper --non-interactive update ;;
+    apk )     apk update && apk upgrade ;;
+    brew )    brew update && brew upgrade ;;
+  esac
+  success "System updated with $pm"
+}
+
 fetch_url() {
   if command -v curl >/dev/null 2>&1; then
     curl -fsSL "$1"
@@ -477,7 +512,7 @@ Commands:
   logs         Show recent logs (follows the log when a single app is targeted)
   version      Show the image versions each app is using
   running      List running containers (docker ps)
-  apt          Update the host system with apt-get (Debian/Ubuntu)
+  system-update  Update the host OS packages (detects apt/dnf/yum/pacman/zypper/apk/brew; 'apt' still works as an alias)
   update-self  Update this script to the latest GitHub release
   help         Show this help (--version shows the script version)
 
@@ -610,14 +645,8 @@ run_command() {
       echo "Getting all running services"
       docker ps
       ;;
-    'apt' )
-      if ! command -v apt-get >/dev/null 2>&1; then
-        error "apt-get not found. This command is only for Debian/Ubuntu systems."
-        exit 1
-      fi
-      echo "Updating system with apt."
-      apt-get update && apt-get upgrade -y
-      success "System updated"
+    'system-update' | 'apt' )
+      system_update
       ;;
     'update-self' | 'updateself' )
       update_self

--- a/docker_volumes/manage.sh
+++ b/docker_volumes/manage.sh
@@ -13,6 +13,9 @@ USERNAME="systemadmin"
 DOCKER_VOLUMES="${DOCKER_VOLUMES:-/home/$USERNAME/docker_volumes/}"
 #Target is the folder within that the tar will save to if running a backup.
 TARGET="${DOCKER_VOLUMES}backup/"
+#Seconds to wait for containers to shut down gracefully before docker gives up
+#(docker's own default of 10s can be too short for busy databases)
+STOP_TIMEOUT="${STOP_TIMEOUT:-30}"
 
 
 #Add styling (only on a terminal that supports it; NO_COLOR=1 disables colour, see no-color.org)
@@ -172,6 +175,23 @@ elapsed() {
   fi
 }
 
+#Per-app results collected during a run, shown as a closing summary
+SUMMARY=""
+record() {
+  SUMMARY="${SUMMARY}$1|$2|$(( $(date +%s) - app_start ))
+"
+}
+print_summary() {
+  if [ -z "$SUMMARY" ] || [ -z "$APP_TOTAL" ] || [ "$APP_TOTAL" -le 1 ]; then
+    return 0
+  fi
+  echo "---"
+  printf '%s' "$SUMMARY" | while IFS='|' read -r s_app s_action s_secs; do
+    [ -z "$s_app" ] && continue
+    printf '  %s%-24s%s %-12s %s%4ss%s\n' "$bold" "$s_app" "$normal" "$s_action" "$dim" "$s_secs" "$normal"
+  done
+}
+
 list_apps() {
   for app in "$@"; do
     echo "$cyan$ARROW$normal $app"
@@ -179,48 +199,73 @@ list_apps() {
   echo "---"
 }
 
+#Pull with docker's own progress bars on a terminal, quietly otherwise
+pull_images() {
+  echo "$(counter)Pulling ${bold}$1${normal} images"
+  if [ -n "$SPINNER" ]; then
+    compose pull
+  else
+    compose pull --quiet
+  fi
+}
+
 start_app() {
+  app_start=$(date +%s)
   enter_app "$1"
   run_step "$(counter)Starting ${bold}$1${normal}" compose up -d
   ok "$(counter)$1 started"
+  record "$1" "started"
   cd ..
 }
 
 stop_app() {
+  app_start=$(date +%s)
   enter_app "$1"
   #stop (not kill) shuts containers down gracefully so databases can finish writing
-  run_step "$(counter)Stopping ${bold}$1${normal}" compose stop
+  run_step "$(counter)Stopping ${bold}$1${normal}" compose stop -t "$STOP_TIMEOUT"
   ok "$(counter)$1 stopped"
+  record "$1" "stopped"
   cd ..
 }
 
 restart_app() {
+  app_start=$(date +%s)
   enter_app "$1"
-  run_step "$(counter)Stopping ${bold}$1${normal}" compose stop
+  run_step "$(counter)Stopping ${bold}$1${normal}" compose stop -t "$STOP_TIMEOUT"
   run_step "$(counter)Starting ${bold}$1${normal}" compose up -d
   ok "$(counter)$1 restarted"
+  record "$1" "restarted"
   cd ..
 }
 
 update_app() {
+  app_start=$(date +%s)
   enter_app "$1"
-  run_step "$(counter)Stopping ${bold}$1${normal}" compose stop
-  echo "$(counter)Pulling ${bold}$1${normal} images"
-  compose pull
+  #Pull while the app is still running so downtime is only the stop/start window
+  pull_images "$1"
+  run_step "$(counter)Stopping ${bold}$1${normal}" compose stop -t "$STOP_TIMEOUT"
   run_step "$(counter)Starting ${bold}$1${normal}" compose up -d
   ok "$(counter)$1 updated and running"
+  record "$1" "updated"
   cd ..
 }
 
 backup_app() {
+  app_start=$(date +%s)
   enter_app "$1"
-  run_step "$(counter)Stopping ${bold}$1${normal}" compose stop
+  #Pull while the app is still running so downtime is only the stop/backup/start window
+  pull_images "$1"
+  run_step "$(counter)Stopping ${bold}$1${normal}" compose stop -t "$STOP_TIMEOUT"
   mkdir -p "$TARGET"
-  run_step "$(counter)Backing up ${bold}$1${normal}" tar -cjf "${TARGET}${1}$(date '+%Y-%m-%d').tar.bz2" "${DOCKER_VOLUMES}${1}"
-  echo "$(counter)Pulling ${bold}$1${normal} images"
-  compose pull
+  archive="${TARGET}${1}$(date '+%Y-%m-%d').tar.bz2"
+  if [ -e "$archive" ]; then
+    warn "${archive##*/} already exists - keeping it and adding a timestamp to this one"
+    archive="${TARGET}${1}$(date '+%Y-%m-%d_%H%M%S').tar.bz2"
+  fi
+  run_step "$(counter)Backing up ${bold}$1${normal}" tar -cjf "$archive" "${DOCKER_VOLUMES}${1}"
   run_step "$(counter)Starting ${bold}$1${normal}" compose up -d
   ok "$(counter)$1 backed up, updated and running"
+  record "$1" "backed up"
   cd ..
 }
 
@@ -254,6 +299,7 @@ run_command() {
   RUN_START=$(date +%s)
   APP_TOTAL=$#
   APP_NUM=0
+  SUMMARY=""
   case "$menu_command" in
     'backup' )
       checkDefault
@@ -264,6 +310,7 @@ run_command() {
         APP_NUM=$((APP_NUM + 1))
         backup_app "$app"
       done
+      print_summary
       success "Backing up completed in $(elapsed)"
       ;;
     'restore' )
@@ -295,6 +342,7 @@ run_command() {
         APP_NUM=$((APP_NUM + 1))
         update_app "$app"
       done
+      print_summary
       success "Services updated in $(elapsed). Give them a moment to warm up."
       ;;
     'stop' )
@@ -306,6 +354,7 @@ run_command() {
         APP_NUM=$((APP_NUM + 1))
         stop_app "$app"
       done
+      print_summary
       success "Services stopped in $(elapsed)"
       ;;
     'start' )
@@ -317,6 +366,7 @@ run_command() {
         APP_NUM=$((APP_NUM + 1))
         start_app "$app"
       done
+      print_summary
       success "Services started in $(elapsed). Give them a moment to warm up."
       ;;
     'restart' )
@@ -327,6 +377,7 @@ run_command() {
         APP_NUM=$((APP_NUM + 1))
         restart_app "$app"
       done
+      print_summary
       success "Services restarted in $(elapsed). Give them a moment to warm up."
       ;;
     'version' )
@@ -429,7 +480,15 @@ interactive() {
         Apps=$PICKED_APP
       fi
     fi
-    run_command "$choice"
+    #Run in a subshell so one failed command reports and returns to the menu
+    #instead of ending the whole session under set -e
+    set +e
+    ( set -e; trap cleanup EXIT; run_command "$choice" )
+    menu_status=$?
+    set -e
+    if [ "$menu_status" -ne 0 ]; then
+      warn "Command finished with errors (exit $menu_status)"
+    fi
   done
 }
 

--- a/docker_volumes/manage.sh
+++ b/docker_volumes/manage.sh
@@ -104,6 +104,19 @@ notify() {
   return 0
 }
 
+#Ask a yes/no question. --yes answers yes; a non-interactive run (cron) also
+#proceeds so scheduled jobs aren't blocked. Returns non-zero if the user says no.
+confirm() {
+  [ -n "${ASSUME_YES:-}" ] && return 0
+  [ -t 0 ] || return 0
+  printf '%s [y/N] ' "$1"
+  read -r cf_ans || cf_ans=""
+  case "$cf_ans" in
+    y | Y | yes | YES ) return 0 ;;
+    * ) return 1 ;;
+  esac
+}
+
 actioninfo() {
   echo "${bold}${cyan}[action]${normal} $ARROW $1"
 }
@@ -125,6 +138,10 @@ error() {
 run_step() {
   step_label=$1
   shift
+  if [ -n "${DRY_RUN:-}" ]; then
+    echo "${dim}[dry-run]${normal} would: $step_label"
+    return 0
+  fi
   if [ -z "$SPINNER" ]; then
     echo "$step_label"
     "$@"
@@ -543,22 +560,26 @@ backup_app() {
   app_start=$(date +%s)
   enter_app "$1"
   run_step "$(counter)Stopping ${bold}$1${normal}" compose stop -t "$STOP_TIMEOUT"
-  mkdir -p "$TARGET"
   archive="${TARGET}${1}$(date '+%Y-%m-%d').tar.bz2"
-  if [ -e "$archive" ]; then
-    warn "${archive##*/} already exists - keeping it and adding a timestamp to this one"
-    archive="${TARGET}${1}$(date '+%Y-%m-%d_%H%M%S').tar.bz2"
+  if [ -z "${DRY_RUN:-}" ]; then
+    mkdir -p "$TARGET"
+    if [ -e "$archive" ]; then
+      warn "${archive##*/} already exists - keeping it and adding a timestamp to this one"
+      archive="${TARGET}${1}$(date '+%Y-%m-%d_%H%M%S').tar.bz2"
+    fi
   fi
   #Relative paths inside the archive make restores portable; 600 keeps the
   #.env secrets inside it private
   run_step "$(counter)Backing up ${bold}$1${normal}" tar -C "$DOCKER_VOLUMES" -cjf "$archive" "$1"
-  chmod 600 "$archive"
-  if [ -n "${BACKUP_KEEP:-}" ]; then
-    # shellcheck disable=SC2012 # archive names are script-generated (no spaces/newlines)
-    ls -1t "${TARGET}${1}"[0-9]*.tar.bz2 2>/dev/null | tail -n +"$((BACKUP_KEEP + 1))" | while IFS= read -r old_backup; do
-      rm -f "$old_backup"
-      warn "Pruned old backup ${old_backup##*/} (BACKUP_KEEP=$BACKUP_KEEP)"
-    done
+  if [ -z "${DRY_RUN:-}" ]; then
+    chmod 600 "$archive"
+    if [ -n "${BACKUP_KEEP:-}" ]; then
+      # shellcheck disable=SC2012 # archive names are script-generated (no spaces/newlines)
+      ls -1t "${TARGET}${1}"[0-9]*.tar.bz2 2>/dev/null | tail -n +"$((BACKUP_KEEP + 1))" | while IFS= read -r old_backup; do
+        rm -f "$old_backup"
+        warn "Pruned old backup ${old_backup##*/} (BACKUP_KEEP=$BACKUP_KEEP)"
+      done
+    fi
   fi
   run_step "$(counter)Starting ${bold}$1${normal}" compose up -d
   wait_healthy "$1" "backed up, updated and running"
@@ -631,16 +652,23 @@ restore_app() {
   fi
 
   echo "$(counter)Restoring ${bold}$1${normal} from ${archive##*/}"
-  if [ -t 0 ]; then
-    printf '%s' "This replaces ${DOCKER_VOLUMES}${1} (current data is set aside, not deleted). Continue? [y/N] "
-    read -r answer || answer=""
-    case "$answer" in
-      y | Y | yes | YES ) ;;
-      * ) echo "Skipped $1."; return 0 ;;
-    esac
-  else
-    error "restore needs a terminal to confirm. Run it interactively."
-    exit 1
+  if [ -n "${DRY_RUN:-}" ]; then
+    echo "${dim}[dry-run]${normal} would replace ${DOCKER_VOLUMES}${1} with the contents of ${archive##*/} (current data set aside)"
+    record "$1" "restored"
+    return 0
+  fi
+  if [ -z "${ASSUME_YES:-}" ]; then
+    if [ -t 0 ]; then
+      printf '%s' "This replaces ${DOCKER_VOLUMES}${1} (current data is set aside, not deleted). Continue? [y/N] "
+      read -r answer || answer=""
+      case "$answer" in
+        y | Y | yes | YES ) ;;
+        * ) echo "Skipped $1."; return 0 ;;
+      esac
+    else
+      error "restore needs a terminal to confirm (or pass --yes). Run it interactively."
+      exit 1
+    fi
   fi
 
   enter_app "$1"
@@ -781,6 +809,11 @@ Commands:
   update-self  Update this script to the latest GitHub release
   help         Show this help (--version shows the script version)
 
+Options:
+  --dry-run    Show what each command would do without touching anything
+  -y, --yes    Don't prompt for confirmation (update / restore)
+  --no-color   Disable coloured output
+
 Commands run against every app in the Apps variable. The default, "auto",
 discovers every folder here that contains a compose file. Pass one or more
 folder names to target specific apps instead, e.g. ./manage.sh restart linkace
@@ -799,7 +832,8 @@ run_command() {
   APP_NUM=0
   SUMMARY=""
   case "$menu_command" in
-    'backup' | 'update' | 'stop' | 'start' | 'restart' | 'restore' ) acquire_lock ;;
+    'backup' | 'update' | 'stop' | 'start' | 'restart' | 'restore' )
+      [ -z "${DRY_RUN:-}" ] && acquire_lock ;;
   esac
   case "$menu_command" in
     'backup' )
@@ -859,6 +893,10 @@ run_command() {
     'update' )
       checkDefault
       require_docker
+      if [ -z "${DRY_RUN:-}" ] && ! confirm "Update $# app(s)? This pulls new images and recreates their containers."; then
+        echo "Cancelled."
+        return 0
+      fi
       NOTIFY_CONTEXT="Update of $*"
       actioninfo "${bold}Updating all services.${normal}"
       list_apps "$@"
@@ -1042,9 +1080,25 @@ interactive() {
   done
 }
 
+#Pull global options out of the arguments (they may appear before or after the
+#command); everything else stays as the command and its app names.
+ASSUME_YES=""
+DRY_RUN=""
+positional=""
+for arg in "$@"; do
+  case "$arg" in
+    -y | --yes ) ASSUME_YES=1 ;;
+    --dry-run ) DRY_RUN=1 ;;
+    --no-color ) bold=""; normal=""; red=""; green=""; yellow=""; cyan=""; dim="" ;;
+    * ) positional="$positional $arg" ;;
+  esac
+done
+# shellcheck disable=SC2086 # app names are space-separated with no embedded spaces
+set -- $positional
+
 APPS_OVERRIDDEN=0
 if [ $# -eq 0 ]; then
-  if [ -t 0 ]; then
+  if [ -t 0 ] && [ -z "$DRY_RUN" ]; then
     #No arguments on a terminal: offer the interactive menu
     interactive
     exit 0

--- a/docker_volumes/manage.sh
+++ b/docker_volumes/manage.sh
@@ -282,6 +282,15 @@ leave_app() {
   cd "$APP_RETURN_DIR"
 }
 
+#Is $1 one of the space-separated words in $2?
+in_list() {
+  # shellcheck disable=SC2086 # $2 is an intentionally space-separated list
+  for il_x in $2; do
+    [ "$il_x" = "$1" ] && return 0
+  done
+  return 1
+}
+
 #Progress counter shown when more than one app is being processed
 APP_NUM="" APP_TOTAL=""
 counter() {
@@ -333,6 +342,84 @@ pull_images() {
   else
     compose pull --quiet
   fi
+}
+
+#How many image pulls to run at once (nala-style). 1 makes pulls sequential.
+PARALLEL_PULLS="${PARALLEL_PULLS:-3}"
+
+#Pull one app's images quietly - used by the parallel orchestrator, where
+#interleaved progress bars would be unreadable.
+_pull_one() {
+  enter_app "$1"
+  compose pull --quiet
+}
+
+#Launch pulls in batches of PARALLEL_PULLS, recording any that fail.
+_pull_orchestrate() {
+  while [ $# -gt 0 ]; do
+    po_pids=""
+    po_c=0
+    while [ $# -gt 0 ] && [ "$po_c" -lt "$PARALLEL_PULLS" ]; do
+      po_app=$1
+      shift
+      po_c=$((po_c + 1))
+      ( _pull_one "$po_app" ) >"$pp_dir/$po_app.log" 2>&1 &
+      po_pid=$!
+      po_pids="$po_pids $po_pid"
+      echo "$po_app" >"$pp_dir/pid.$po_pid"
+    done
+    # shellcheck disable=SC2086 # pids are numeric, space-separated on purpose
+    for po_pid in $po_pids; do
+      if ! wait "$po_pid"; then
+        cat "$pp_dir/pid.$po_pid" >>"$pp_dir/failed"
+      fi
+    done
+  done
+}
+
+#Pull images for several apps concurrently. Sets PULL_FAILED to the apps whose
+#pull failed; the caller leaves those on their current image and skips them.
+parallel_pull() {
+  PULL_FAILED=""
+  [ $# -eq 0 ] && return 0
+  if [ -n "${DRY_RUN:-}" ]; then
+    for pp_app in "$@"; do
+      echo "${dim}[dry-run]${normal} would pull ${bold}$pp_app${normal} images"
+    done
+    return 0
+  fi
+  pp_total=$#
+  pp_dir=$(mktemp -d "${TMPDIR:-/tmp}/dockerdance-pull.XXXXXX" 2>/dev/null) || { pp_dir="${TMPDIR:-/tmp}/dockerdance-pull.$$"; mkdir -p "$pp_dir"; }
+  : >"$pp_dir/failed"
+  #Run the orchestrator in the background so one spinner can cover the phase.
+  ( _pull_orchestrate "$@" ) >"$pp_dir/orch.log" 2>&1 &
+  pp_orch=$!
+  pp_label="Pulling images for $pp_total app(s), up to $PARALLEL_PULLS at a time"
+  if [ -n "$SPINNER" ]; then
+    tput civis 2>/dev/null || true
+    while kill -0 "$pp_orch" 2>/dev/null; do
+      # shellcheck disable=SC2086 # frames are an intentionally space-separated list
+      for pp_frame in $SPINNER_FRAMES; do
+        kill -0 "$pp_orch" 2>/dev/null || break
+        printf '\r%s%s%s %s' "$cyan" "$pp_frame" "$normal" "$pp_label"
+        sleep 0.1 2>/dev/null || sleep 1
+      done
+    done
+    printf '\r'
+    tput el 2>/dev/null || printf '%-79s\r' ''
+    tput cnorm 2>/dev/null || true
+    wait "$pp_orch" || true
+  else
+    echo "$pp_label..."
+    wait "$pp_orch" || true
+  fi
+  PULL_FAILED=$(tr '\n' ' ' <"$pp_dir/failed")
+  PULL_FAILED=${PULL_FAILED% }
+  for pp_app in $PULL_FAILED; do
+    warn "Pull failed for $pp_app - leaving it on its current image"
+    [ -s "$pp_dir/$pp_app.log" ] && sed 's/^/    /' "$pp_dir/$pp_app.log" >&2
+  done
+  rm -rf "$pp_dir"
 }
 
 #Wait for an app's containers to come up healthy after starting. Containers
@@ -438,11 +525,11 @@ restart_app() {
   leave_app
 }
 
+#Images are pulled up front (in parallel) by the caller, so this just cycles
+#the app onto the new image with minimal downtime.
 update_app() {
   app_start=$(date +%s)
   enter_app "$1"
-  #Pull while the app is still running so downtime is only the stop/start window
-  pull_images "$1"
   run_step "$(counter)Stopping ${bold}$1${normal}" compose stop -t "$STOP_TIMEOUT"
   run_step "$(counter)Starting ${bold}$1${normal}" compose up -d
   wait_healthy "$1" "updated and running"
@@ -450,11 +537,11 @@ update_app() {
   leave_app
 }
 
+#Images are pulled up front (in parallel) by the caller; this stops, archives
+#and starts the app back on the new image.
 backup_app() {
   app_start=$(date +%s)
   enter_app "$1"
-  #Pull while the app is still running so downtime is only the stop/backup/start window
-  pull_images "$1"
   run_step "$(counter)Stopping ${bold}$1${normal}" compose stop -t "$STOP_TIMEOUT"
   mkdir -p "$TARGET"
   archive="${TARGET}${1}$(date '+%Y-%m-%d').tar.bz2"
@@ -721,8 +808,15 @@ run_command() {
       NOTIFY_CONTEXT="Backup of $*"
       actioninfo "${bold}Backing up${normal} apps including:"
       list_apps "$@"
+      parallel_pull "$@"
       for app in "$@"; do
         APP_NUM=$((APP_NUM + 1))
+        if in_list "$app" "$PULL_FAILED"; then
+          app_start=$(date +%s)
+          warn "$(counter)Skipping $app (its pull failed)"
+          record "$app" "skipped"
+          continue
+        fi
         backup_app "$app"
       done
       print_summary
@@ -768,12 +862,19 @@ run_command() {
       NOTIFY_CONTEXT="Update of $*"
       actioninfo "${bold}Updating all services.${normal}"
       list_apps "$@"
+      parallel_pull "$@"
       for app in "$@"; do
         APP_NUM=$((APP_NUM + 1))
+        if in_list "$app" "$PULL_FAILED"; then
+          app_start=$(date +%s)
+          warn "$(counter)Skipping $app (its pull failed)"
+          record "$app" "skipped"
+          continue
+        fi
         update_app "$app"
       done
       print_summary
-      success "Services updated in $(elapsed). Give them a moment to warm up."
+      success "Services updated in $(elapsed)."
       notify "Update of $* completed in $(elapsed)"
       NOTIFY_CONTEXT=""
       ;;

--- a/docker_volumes/manage.sh
+++ b/docker_volumes/manage.sh
@@ -11,7 +11,8 @@ Apps="example"
 USERNAME="systemadmin"
 
 #Optional config file: put Apps/USERNAME (plus DOCKER_VOLUMES, STOP_TIMEOUT,
-#BACKUP_KEEP) in a manage.conf next to the script and they survive update-self
+#BACKUP_KEEP, NOTIFY_WEBHOOK) in a manage.conf next to the script and they
+#survive update-self
 if [ -f "./manage.conf" ]; then
   # shellcheck source=/dev/null
   . "./manage.conf"
@@ -68,16 +69,35 @@ STEP_LOG="${TMPDIR:-/tmp}/dockerdance-step.$$.log"
 #against a cron backup overlapping a manual update)
 LOCK_DIR="${TMPDIR:-/tmp}/dockerdance$(pwd | tr '/ ' '__').lock"
 HAVE_LOCK=""
+NOTIFY_CONTEXT=""
 cleanup() {
+  cleanup_status=$?
   tput cnorm 2>/dev/null || true
   rm -f "$STEP_LOG"
   if [ -n "$HAVE_LOCK" ]; then
     rmdir "$LOCK_DIR" 2>/dev/null || true
   fi
+  if [ "$cleanup_status" -ne 0 ] && [ -n "$NOTIFY_CONTEXT" ]; then
+    notify "$NOTIFY_CONTEXT failed (exit $cleanup_status)"
+  fi
 }
 trap cleanup EXIT
 trap 'exit 130' INT
 trap 'exit 143' TERM
+
+#NOTIFY_WEBHOOK (optional, set in manage.conf or the environment): URL that
+#receives a message when update/backup/restore completes or fails. The JSON
+#payload suits Slack ("text") and Discord ("content") webhooks. Issue #3.
+notify() {
+  [ -z "${NOTIFY_WEBHOOK:-}" ] && return 0
+  notify_payload="{\"text\": \"DockerDance: $1\", \"content\": \"DockerDance: $1\"}"
+  if command -v curl >/dev/null 2>&1; then
+    curl -fsS -m 10 -H 'Content-Type: application/json' -d "$notify_payload" "$NOTIFY_WEBHOOK" >/dev/null 2>&1 || warn "Webhook notification failed"
+  elif command -v wget >/dev/null 2>&1; then
+    wget -q -T 10 --header 'Content-Type: application/json' --post-data "$notify_payload" -O /dev/null "$NOTIFY_WEBHOOK" 2>/dev/null || warn "Webhook notification failed"
+  fi
+  return 0
+}
 
 actioninfo() {
   echo "${bold}${cyan}[action]${normal} $ARROW $1"
@@ -179,12 +199,44 @@ checkDefault() {
   fi
 }
 
+has_compose_file() {
+  [ -f "$1/docker-compose.yml" ] || [ -f "$1/docker-compose.yaml" ] || [ -f "$1/compose.yml" ] || [ -f "$1/compose.yaml" ]
+}
+
 enter_app() {
+  APP_RETURN_DIR=$(pwd)
   if [ ! -d "$1" ]; then
     error "No folder named '$1' here. Run this from the docker_volumes folder and check the Apps variable / arguments."
     exit 1
   fi
   cd "$1"
+  if has_compose_file .; then
+    return 0
+  fi
+  #The compose file may sit one folder deeper (issue #6) - follow it when unambiguous
+  nested=""
+  nested_count=0
+  for nested_dir in */; do
+    [ -d "$nested_dir" ] || continue
+    if has_compose_file "$nested_dir"; then
+      nested=$nested_dir
+      nested_count=$((nested_count + 1))
+    fi
+  done
+  if [ "$nested_count" -eq 1 ]; then
+    cd "$nested"
+    return 0
+  fi
+  if [ "$nested_count" -gt 1 ]; then
+    error "'$1' contains several nested folders with compose files - list those folders in Apps directly."
+  else
+    error "No compose file found in '$1' (or one level below it)."
+  fi
+  exit 1
+}
+
+leave_app() {
+  cd "$APP_RETURN_DIR"
 }
 
 #Progress counter shown when more than one app is being processed
@@ -246,7 +298,7 @@ start_app() {
   run_step "$(counter)Starting ${bold}$1${normal}" compose up -d
   ok "$(counter)$1 started"
   record "$1" "started"
-  cd ..
+  leave_app
 }
 
 stop_app() {
@@ -256,7 +308,7 @@ stop_app() {
   run_step "$(counter)Stopping ${bold}$1${normal}" compose stop -t "$STOP_TIMEOUT"
   ok "$(counter)$1 stopped"
   record "$1" "stopped"
-  cd ..
+  leave_app
 }
 
 restart_app() {
@@ -266,7 +318,7 @@ restart_app() {
   run_step "$(counter)Starting ${bold}$1${normal}" compose up -d
   ok "$(counter)$1 restarted"
   record "$1" "restarted"
-  cd ..
+  leave_app
 }
 
 update_app() {
@@ -278,7 +330,7 @@ update_app() {
   run_step "$(counter)Starting ${bold}$1${normal}" compose up -d
   ok "$(counter)$1 updated and running"
   record "$1" "updated"
-  cd ..
+  leave_app
 }
 
 backup_app() {
@@ -307,7 +359,57 @@ backup_app() {
   run_step "$(counter)Starting ${bold}$1${normal}" compose up -d
   ok "$(counter)$1 backed up, updated and running"
   record "$1" "backed up"
-  cd ..
+  leave_app
+}
+
+#Restore the newest backup for an app (issue #2). Current data is moved
+#aside - never deleted - so a bad restore is always reversible by hand.
+restore_app() {
+  app_start=$(date +%s)
+  # shellcheck disable=SC2012 # archive names are script-generated (no spaces/newlines)
+  archive=$(ls -1t "${TARGET}${1}"[0-9]*.tar.bz2 2>/dev/null | head -1)
+  if [ -z "$archive" ]; then
+    error "No backups found for '$1' in $TARGET"
+    exit 1
+  fi
+  #Which layout is inside? New backups hold '<app>/...', pre-v0.2.0 ones held absolute paths
+  first_member=$(tar -tjf "$archive" 2>/dev/null | head -1)
+  case "$first_member" in
+    "$1"/* ) restore_root=$DOCKER_VOLUMES ;;
+    *docker_volumes/"$1"/* ) restore_root="/" ;;
+    * )
+      error "Unrecognised layout in ${archive##*/} - restore it manually with tar."
+      exit 1
+      ;;
+  esac
+  echo "$(counter)Restoring ${bold}$1${normal} from ${archive##*/}"
+  if [ -t 0 ]; then
+    printf '%s' "This replaces ${DOCKER_VOLUMES}${1} (current data is set aside, not deleted). Continue? [y/N] "
+    read -r answer || answer=""
+    case "$answer" in
+      y | Y | yes | YES ) ;;
+      * ) echo "Skipped $1."; return 0 ;;
+    esac
+  else
+    error "restore needs a terminal to confirm. Run it interactively."
+    exit 1
+  fi
+  enter_app "$1"
+  run_step "$(counter)Stopping ${bold}$1${normal}" compose stop -t "$STOP_TIMEOUT"
+  leave_app
+  aside="${DOCKER_VOLUMES}${1}.pre-restore.$(date '+%Y%m%d%H%M%S')"
+  mv "${DOCKER_VOLUMES}${1}" "$aside"
+  if ! run_step "$(counter)Extracting ${bold}${archive##*/}${normal}" tar -xjf "$archive" -C "$restore_root"; then
+    rm -rf "${DOCKER_VOLUMES:?}${1}"
+    mv "$aside" "${DOCKER_VOLUMES}${1}"
+    error "Restore failed - the original data was put back."
+    exit 1
+  fi
+  enter_app "$1"
+  run_step "$(counter)Starting ${bold}$1${normal}" compose up -d
+  leave_app
+  ok "$(counter)$1 restored. Previous data kept at ${aside##*/} - delete it once you're happy"
+  record "$1" "restored"
 }
 
 fetch_url() {
@@ -371,6 +473,7 @@ Commands:
   restart      Stop apps, then start them again
   update       Pull the latest images, then restart apps on them
   backup       Pull, stop, tar app folders into the backup folder, then start again
+  restore      Put the newest backup archive back in place (current data is set aside)
   logs         Show recent logs (follows the log when a single app is targeted)
   version      Show the image versions each app is using
   running      List running containers (docker ps)
@@ -392,12 +495,13 @@ run_command() {
   APP_NUM=0
   SUMMARY=""
   case "$menu_command" in
-    'backup' | 'update' | 'stop' | 'start' | 'restart' ) acquire_lock ;;
+    'backup' | 'update' | 'stop' | 'start' | 'restart' | 'restore' ) acquire_lock ;;
   esac
   case "$menu_command" in
     'backup' )
       checkDefault
       require_docker
+      NOTIFY_CONTEXT="Backup of $*"
       actioninfo "${bold}Backing up${normal} apps including:"
       list_apps "$@"
       for app in "$@"; do
@@ -406,9 +510,23 @@ run_command() {
       done
       print_summary
       success "Backing up completed in $(elapsed)"
+      notify "Backup of $* completed in $(elapsed)"
+      NOTIFY_CONTEXT=""
       ;;
     'restore' )
-      echo "Coming soon:"
+      checkDefault
+      require_docker
+      NOTIFY_CONTEXT="Restore of $*"
+      actioninfo "${bold}Restoring${normal} apps from their latest backups:"
+      list_apps "$@"
+      for app in "$@"; do
+        APP_NUM=$((APP_NUM + 1))
+        restore_app "$app"
+      done
+      print_summary
+      success "Restore completed in $(elapsed)"
+      notify "Restore of $* completed in $(elapsed)"
+      NOTIFY_CONTEXT=""
       ;;
     'logs' )
       checkDefault
@@ -417,19 +535,20 @@ run_command() {
         echo "Following ${bold}$1${normal} logs (Ctrl-C to stop)"
         enter_app "$1"
         compose logs -f
-        cd ..
+        leave_app
       else
         for app in "$@"; do
           echo "Getting ${bold}$app${normal} logs"
           enter_app "$app"
           compose logs --tail=20
-          cd ..
+          leave_app
         done
       fi
       ;;
     'update' )
       checkDefault
       require_docker
+      NOTIFY_CONTEXT="Update of $*"
       actioninfo "${bold}Updating all services.${normal}"
       list_apps "$@"
       for app in "$@"; do
@@ -438,6 +557,8 @@ run_command() {
       done
       print_summary
       success "Services updated in $(elapsed). Give them a moment to warm up."
+      notify "Update of $* completed in $(elapsed)"
+      NOTIFY_CONTEXT=""
       ;;
     'stop' )
       checkDefault
@@ -481,7 +602,7 @@ run_command() {
         echo "Getting ${bold}$app${normal} version"
         enter_app "$app"
         compose images
-        cd ..
+        leave_app
       done
       ;;
     'running' )
@@ -570,8 +691,9 @@ interactive() {
     echo ""
     echo "${bold}${cyan}DockerDance${normal} ${dim}v$VERSION${normal} - what would you like to do?"
     echo "  1) start    2) stop     3) restart"
-    echo "  4) update   5) backup   6) logs"
-    echo "  7) version  8) running  q) quit"
+    echo "  4) update   5) backup   6) restore"
+    echo "  7) logs     8) version  9) running"
+    echo "  q) quit"
     printf "> "
     read -r choice || break
     case "$choice" in
@@ -580,9 +702,10 @@ interactive() {
       3 ) choice="restart" ;;
       4 ) choice="update" ;;
       5 ) choice="backup" ;;
-      6 ) choice="logs" ;;
-      7 ) choice="version" ;;
-      8 ) choice="running" ;;
+      6 ) choice="restore" ;;
+      7 ) choice="logs" ;;
+      8 ) choice="version" ;;
+      9 ) choice="running" ;;
       q | Q | quit | exit ) break ;;
       * ) echo "Not a valid choice."; continue ;;
     esac

--- a/docker_volumes/manage.sh
+++ b/docker_volumes/manage.sh
@@ -6,8 +6,11 @@ VERSION="0.2.0"
 SELF_REPO="${DOCKERDANCE_REPO:-AdamXweb/DockerDance}"
 
 #Set these variables!
-#Apps to backup (according to the folder name). Add each one with a space in between e.g. "vaultwarden uptime-kuma"
-Apps="example"
+#Apps to manage. "auto" (the default) discovers every folder here that holds a
+#compose file (docker-compose.yml/.yaml or compose.yml/.yaml, or one folder
+#deeper), skipping backup/ and *.pre-restore.* folders. Or list folder names
+#with a space in between e.g. "vaultwarden uptime-kuma" to pin the set/order.
+Apps="auto"
 USERNAME="systemadmin"
 
 #Optional config file: put Apps/USERNAME (plus DOCKER_VOLUMES, STOP_TIMEOUT,
@@ -194,7 +197,45 @@ checkDefault() {
     return 0
   fi
   if [ "$Apps" = "example" ]; then
-    error "Please change the default 'Apps' variable to include your apps (or pass app names after the command)."
+    error "Please change the 'Apps' variable: list your apps, or set Apps=\"auto\" to manage every folder here with a compose file."
+    exit 1
+  fi
+}
+
+#Apps="auto": build the app list from the folders actually present
+discover_apps() {
+  found=""
+  #the extra patterns pick up hidden apps like .n8n while skipping . and ..
+  for d in */ .[!.]*/ ..?*/; do
+    [ -d "$d" ] || continue
+    d=${d%/}
+    case "$d" in
+      backup | *.pre-restore.* ) continue ;;
+    esac
+    if has_compose_file "$d"; then
+      found="$found $d"
+      continue
+    fi
+    for sub in "$d"/*/; do
+      [ -d "$sub" ] || continue
+      if has_compose_file "$sub"; then
+        found="$found $d"
+        break
+      fi
+    done
+  done
+  Apps=${found# }
+}
+
+maybe_discover_apps() {
+  [ "$APPS_OVERRIDDEN" = "1" ] && return 0
+  case "$Apps" in
+    'auto' | '' ) ;;
+    * ) return 0 ;;
+  esac
+  discover_apps
+  if [ -z "$Apps" ]; then
+    error "Apps=\"auto\" found no folders with a compose file in $(pwd). Run this from your docker_volumes folder."
     exit 1
   fi
 }
@@ -516,13 +557,17 @@ Commands:
   update-self  Update this script to the latest GitHub release
   help         Show this help (--version shows the script version)
 
-Commands run against every app in the Apps variable. Pass one or more
+Commands run against every app in the Apps variable. The default, "auto",
+discovers every folder here that contains a compose file. Pass one or more
 folder names to target specific apps instead, e.g. ./manage.sh restart linkace
 EOF
 }
 
 run_command() {
   menu_command=$1
+  case "$menu_command" in
+    'backup' | 'restore' | 'update' | 'stop' | 'start' | 'restart' | 'logs' | 'version' ) maybe_discover_apps ;;
+  esac
   # shellcheck disable=SC2086 # Apps is an intentionally space-separated list
   set -- $Apps
   RUN_START=$(date +%s)
@@ -715,6 +760,7 @@ pick_app() {
 interactive() {
   checkDefault
   require_docker
+  maybe_discover_apps
   ALL_APPS=$Apps
   while :; do
     echo ""

--- a/docker_volumes/manage.sh
+++ b/docker_volumes/manage.sh
@@ -1,10 +1,21 @@
 #!/bin/sh
 set -e
 
+VERSION="0.2.0"
+#Repo used by update-self; override with DOCKERDANCE_REPO=owner/name
+SELF_REPO="${DOCKERDANCE_REPO:-AdamXweb/DockerDance}"
+
 #Set these variables!
 #Apps to backup (according to the folder name). Add each one with a space in between e.g. "vaultwarden uptime-kuma"
 Apps="example"
 USERNAME="systemadmin"
+
+#Optional config file: put Apps/USERNAME (plus DOCKER_VOLUMES, STOP_TIMEOUT,
+#BACKUP_KEEP) in a manage.conf next to the script and they survive update-self
+if [ -f "./manage.conf" ]; then
+  # shellcheck source=/dev/null
+  . "./manage.conf"
+fi
 
 #Specific to Linux. Can change these if needed
 #Set folder from root to avoid permission issues if running script as different user. (this would be /home/systemadmin/docker_volumes)
@@ -47,11 +58,22 @@ case "${LC_ALL:-${LC_CTYPE:-${LANG:-}}}" in
     ARROW='=>'
     ;;
 esac
+case "$SPINNER_FRAMES" in
+  ⠋* ) DOT_ON='●' DOT_OFF='○' ;;
+  * )  DOT_ON='*' DOT_OFF='-' ;;
+esac
 
 STEP_LOG="${TMPDIR:-/tmp}/dockerdance-step.$$.log"
+#One state-changing run at a time per docker_volumes folder (protects
+#against a cron backup overlapping a manual update)
+LOCK_DIR="${TMPDIR:-/tmp}/dockerdance$(pwd | tr '/ ' '__').lock"
+HAVE_LOCK=""
 cleanup() {
   tput cnorm 2>/dev/null || true
   rm -f "$STEP_LOG"
+  if [ -n "$HAVE_LOCK" ]; then
+    rmdir "$LOCK_DIR" 2>/dev/null || true
+  fi
 }
 trap cleanup EXIT
 trap 'exit 130' INT
@@ -107,6 +129,15 @@ run_step() {
   fi
   rm -f "$STEP_LOG"
   return 0
+}
+
+acquire_lock() {
+  [ -n "$HAVE_LOCK" ] && return 0
+  if ! mkdir "$LOCK_DIR" 2>/dev/null; then
+    error "Another manage.sh run appears to be active here (lock: $LOCK_DIR). Remove that folder if it's stale."
+    exit 1
+  fi
+  HAVE_LOCK=1
 }
 
 #Check Docker is installed, the daemon is reachable and compose is available
@@ -262,30 +293,90 @@ backup_app() {
     warn "${archive##*/} already exists - keeping it and adding a timestamp to this one"
     archive="${TARGET}${1}$(date '+%Y-%m-%d_%H%M%S').tar.bz2"
   fi
-  run_step "$(counter)Backing up ${bold}$1${normal}" tar -cjf "$archive" "${DOCKER_VOLUMES}${1}"
+  #Relative paths inside the archive make restores portable; 600 keeps the
+  #.env secrets inside it private
+  run_step "$(counter)Backing up ${bold}$1${normal}" tar -C "$DOCKER_VOLUMES" -cjf "$archive" "$1"
+  chmod 600 "$archive"
+  if [ -n "${BACKUP_KEEP:-}" ]; then
+    # shellcheck disable=SC2012 # archive names are script-generated (no spaces/newlines)
+    ls -1t "${TARGET}${1}"[0-9]*.tar.bz2 2>/dev/null | tail -n +"$((BACKUP_KEEP + 1))" | while IFS= read -r old_backup; do
+      rm -f "$old_backup"
+      warn "Pruned old backup ${old_backup##*/} (BACKUP_KEEP=$BACKUP_KEEP)"
+    done
+  fi
   run_step "$(counter)Starting ${bold}$1${normal}" compose up -d
   ok "$(counter)$1 backed up, updated and running"
   record "$1" "backed up"
   cd ..
 }
 
+fetch_url() {
+  if command -v curl >/dev/null 2>&1; then
+    curl -fsSL "$1"
+  elif command -v wget >/dev/null 2>&1; then
+    wget -qO- "$1"
+  else
+    error "curl or wget is required to download updates."
+    exit 1
+  fi
+}
+
+update_self() {
+  actioninfo "Checking the latest ${bold}$SELF_REPO${normal} release"
+  latest_tag=$(fetch_url "https://api.github.com/repos/$SELF_REPO/releases/latest" | sed -n 's/.*"tag_name"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -1)
+  if [ -z "$latest_tag" ]; then
+    error "Couldn't find a release for $SELF_REPO. Are you online?"
+    exit 1
+  fi
+  new_script="$0.new.$$"
+  if ! fetch_url "https://raw.githubusercontent.com/$SELF_REPO/$latest_tag/docker_volumes/manage.sh" > "$new_script"; then
+    rm -f "$new_script"
+    error "Downloading manage.sh at $latest_tag failed."
+    exit 1
+  fi
+  new_version=$(sed -n 's/^VERSION="\(.*\)"$/\1/p' "$new_script" | head -1)
+  if [ -z "$new_version" ]; then
+    rm -f "$new_script"
+    error "Release $latest_tag predates self-updating (it has no VERSION). Update manually from https://github.com/$SELF_REPO/releases"
+    exit 1
+  fi
+  if [ "$new_version" = "$VERSION" ]; then
+    rm -f "$new_script"
+    success "Already up to date (v$VERSION, release $latest_tag)."
+    return 0
+  fi
+  if ! sh -n "$new_script" 2>/dev/null; then
+    rm -f "$new_script"
+    error "The downloaded script failed a syntax check - not installing it."
+    exit 1
+  fi
+  #Carry the Apps/USERNAME configured in this copy across the update
+  #(put them in manage.conf to avoid relying on this)
+  sed "s|^Apps=\".*\"|Apps=\"$ORIGINAL_APPS\"|; s|^USERNAME=\".*\"|USERNAME=\"$USERNAME\"|" "$new_script" > "$new_script.tmp"
+  mv "$new_script.tmp" "$new_script"
+  chmod +x "$new_script"
+  mv "$new_script" "$0"
+  success "Updated v$VERSION -> v$new_version ($latest_tag). Apps/USERNAME configuration carried over."
+}
+
 usage() {
   cat <<EOF
-${bold}${cyan}DockerDance${normal} - bulk manage docker compose apps
+${bold}${cyan}DockerDance${normal} v$VERSION - bulk manage docker compose apps
 
 Usage: ./manage.sh <command> [app ...]
 
 Commands:
-  start     Start apps (docker compose up -d)
-  stop      Stop apps gracefully (docker compose stop)
-  restart   Stop apps, then start them again
-  update    Stop apps, pull the latest images and start them again
-  backup    Stop apps, tar their folders into the backup folder, then update and start them
-  logs      Show recent logs (follows the log when a single app is targeted)
-  version   Show the image versions each app is using
-  running   List running containers (docker ps)
-  apt       Update the host system with apt-get (Debian/Ubuntu)
-  help      Show this help
+  start        Start apps (docker compose up -d)
+  stop         Stop apps gracefully (docker compose stop)
+  restart      Stop apps, then start them again
+  update       Pull the latest images, then restart apps on them
+  backup       Pull, stop, tar app folders into the backup folder, then start again
+  logs         Show recent logs (follows the log when a single app is targeted)
+  version      Show the image versions each app is using
+  running      List running containers (docker ps)
+  apt          Update the host system with apt-get (Debian/Ubuntu)
+  update-self  Update this script to the latest GitHub release
+  help         Show this help (--version shows the script version)
 
 Commands run against every app in the Apps variable. Pass one or more
 folder names to target specific apps instead, e.g. ./manage.sh restart linkace
@@ -300,6 +391,9 @@ run_command() {
   APP_TOTAL=$#
   APP_NUM=0
   SUMMARY=""
+  case "$menu_command" in
+    'backup' | 'update' | 'stop' | 'start' | 'restart' ) acquire_lock ;;
+  esac
   case "$menu_command" in
     'backup' )
       checkDefault
@@ -404,6 +498,12 @@ run_command() {
       apt-get update && apt-get upgrade -y
       success "System updated"
       ;;
+    'update-self' | 'updateself' )
+      update_self
+      ;;
+    '--version' | '-V' )
+      echo "DockerDance manage.sh v$VERSION"
+      ;;
     'help' | '-h' | '--help' )
       usage
       ;;
@@ -415,21 +515,35 @@ run_command() {
   esac
 }
 
+#Green dot when a container whose compose project matches the app folder is up.
+#Best-effort: compose lowercases project names and strips leading symbols.
+status_dot() {
+  sd_proj=$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]' | sed 's/^[^a-z0-9]*//')
+  if [ -n "$sd_proj" ] && printf '%s\n' "$RUNNING_NAMES" | grep -q "^${sd_proj}[-_]"; then
+    printf '%s%s%s' "$green" "$DOT_ON" "$normal"
+  else
+    printf '%s%s%s' "$dim" "$DOT_OFF" "$normal"
+  fi
+}
+
 pick_app() {
   #Sets PICKED_APP to one app name, or "" for all apps. Returns 1 if cancelled.
   PICKED_APP=""
   if command -v fzf >/dev/null 2>&1; then
-    PICKED_APP=$(printf '%s\n' "all apps" "$@" | fzf --prompt="app> ") || return 1
+    #The preview pane shows live container status for the highlighted app
+    fzf_preview='if [ {} = "all apps" ]; then docker ps; else (cd {} && '"$DOCKER_COMPOSE_COMMAND"' ps) 2>/dev/null || echo "(no status)"; fi'
+    PICKED_APP=$(printf '%s\n' "all apps" "$@" | fzf --prompt="app> " --preview "$fzf_preview") || return 1
     if [ "$PICKED_APP" = "all apps" ]; then
       PICKED_APP=""
     fi
     return 0
   fi
+  RUNNING_NAMES=$(docker ps --format '{{.Names}}' 2>/dev/null || true)
   n=0
   echo "  0) all apps"
   for app in "$@"; do
     n=$((n + 1))
-    echo "  $n) $app"
+    echo "  $n) $(status_dot "$app") $app"
   done
   printf "Select an app [0-%s]: " "$n"
   read -r selection || return 1
@@ -454,7 +568,7 @@ interactive() {
   ALL_APPS=$Apps
   while :; do
     echo ""
-    echo "${bold}${cyan}DockerDance${normal} - what would you like to do?"
+    echo "${bold}${cyan}DockerDance${normal} ${dim}v$VERSION${normal} - what would you like to do?"
     echo "  1) start    2) stop     3) restart"
     echo "  4) update   5) backup   6) logs"
     echo "  7) version  8) running  q) quit"
@@ -483,7 +597,7 @@ interactive() {
     #Run in a subshell so one failed command reports and returns to the menu
     #instead of ending the whole session under set -e
     set +e
-    ( set -e; trap cleanup EXIT; run_command "$choice" )
+    ( set -e; trap cleanup EXIT; trap 'exit 130' INT; trap 'exit 143' TERM; run_command "$choice" )
     menu_status=$?
     set -e
     if [ "$menu_status" -ne 0 ]; then
@@ -505,6 +619,9 @@ fi
 
 COMMAND=$1
 shift
+#Remember the configured list: update-self writes it into the new script even
+#when this run targeted specific apps
+ORIGINAL_APPS=$Apps
 if [ $# -gt 0 ]; then
   #Remaining arguments target specific apps, e.g. ./manage.sh restart linkace
   Apps="$*"

--- a/docker_volumes/manage.sh
+++ b/docker_volumes/manage.sh
@@ -335,11 +335,85 @@ pull_images() {
   fi
 }
 
+#Wait for an app's containers to come up healthy after starting. Containers
+#with a healthcheck must report 'healthy'; those without just need to be
+#running. Best-effort and never fails the run - it gives up after
+#HEALTH_TIMEOUT seconds (set HEALTH_TIMEOUT=0 to skip the wait entirely).
+#Call from inside the app dir. $2 is the verb for the result line, or "" to
+#stay quiet unless something is wrong. Uses `docker inspect` rather than
+#parsing `compose ps --format json`, whose shape varies across versions.
+HEALTH_TIMEOUT="${HEALTH_TIMEOUT:-60}"
+wait_healthy() {
+  wh_app=$1
+  wh_verb=${2:-}
+  [ -n "${DRY_RUN:-}" ] && return 0
+  if ! [ "${HEALTH_TIMEOUT:-0}" -gt 0 ] 2>/dev/null; then
+    [ -n "$wh_verb" ] && ok "$(counter)$wh_app $wh_verb"
+    return 0
+  fi
+  wh_deadline=$(( $(date +%s) + HEALTH_TIMEOUT ))
+  wh_label="$(counter)Waiting for ${bold}$wh_app${normal} to be healthy"
+  [ -n "$SPINNER" ] && { tput civis 2>/dev/null || true; }
+  wh_rc=0
+  wh_result=""
+  wh_hchecks=0
+  while :; do
+    wh_ids=$(compose ps -q 2>/dev/null)
+    if [ -z "$wh_ids" ]; then wh_rc=1; wh_result="no containers came up"; break; fi
+    wh_total=0; wh_up=0; wh_unhealthy=0; wh_starting=0; wh_hchecks=0
+    # shellcheck disable=SC2086 # ids are one-per-line with no spaces
+    for wh_id in $wh_ids; do
+      wh_total=$((wh_total + 1))
+      wh_st=$(docker inspect -f '{{.State.Status}}' "$wh_id" 2>/dev/null)
+      [ "$wh_st" = "running" ] && wh_up=$((wh_up + 1))
+      wh_h=$(docker inspect -f '{{if .State.Health}}{{.State.Health.Status}}{{end}}' "$wh_id" 2>/dev/null)
+      case "$wh_h" in
+        healthy )   wh_hchecks=$((wh_hchecks + 1)) ;;
+        unhealthy ) wh_hchecks=$((wh_hchecks + 1)); wh_unhealthy=$((wh_unhealthy + 1)) ;;
+        starting )  wh_hchecks=$((wh_hchecks + 1)); wh_starting=$((wh_starting + 1)) ;;
+      esac
+    done
+    if [ "$wh_unhealthy" -gt 0 ]; then wh_rc=1; wh_result="a container is unhealthy"; break; fi
+    if [ "$wh_up" -eq "$wh_total" ] && [ "$wh_starting" -eq 0 ]; then wh_rc=0; break; fi
+    if [ "$(date +%s)" -ge "$wh_deadline" ]; then wh_rc=1; wh_result="still not healthy after ${HEALTH_TIMEOUT}s"; break; fi
+    if [ -n "$SPINNER" ]; then
+      # shellcheck disable=SC2086 # frames are an intentionally space-separated list
+      for wh_frame in $SPINNER_FRAMES; do
+        printf '\r%s%s%s %s' "$cyan" "$wh_frame" "$normal" "$wh_label"
+        sleep 0.1 2>/dev/null || sleep 1
+      done
+    else
+      sleep 2
+    fi
+  done
+  if [ -n "$SPINNER" ]; then
+    printf '\r'
+    tput el 2>/dev/null || printf '%-79s\r' ''
+    tput cnorm 2>/dev/null || true
+  fi
+  if [ "$wh_rc" -eq 0 ]; then
+    if [ -n "$wh_verb" ]; then
+      if [ "$wh_hchecks" -gt 0 ]; then
+        ok "$(counter)$wh_app $wh_verb, healthy"
+      else
+        ok "$(counter)$wh_app $wh_verb"
+      fi
+    fi
+  else
+    if [ -n "$wh_verb" ]; then
+      warn "$(counter)$wh_app $wh_verb, but $wh_result"
+    else
+      warn "$(counter)$wh_app $wh_result"
+    fi
+  fi
+  return 0
+}
+
 start_app() {
   app_start=$(date +%s)
   enter_app "$1"
   run_step "$(counter)Starting ${bold}$1${normal}" compose up -d
-  ok "$(counter)$1 started"
+  wait_healthy "$1" "started"
   record "$1" "started"
   leave_app
 }
@@ -359,7 +433,7 @@ restart_app() {
   enter_app "$1"
   run_step "$(counter)Stopping ${bold}$1${normal}" compose stop -t "$STOP_TIMEOUT"
   run_step "$(counter)Starting ${bold}$1${normal}" compose up -d
-  ok "$(counter)$1 restarted"
+  wait_healthy "$1" "restarted"
   record "$1" "restarted"
   leave_app
 }
@@ -371,7 +445,7 @@ update_app() {
   pull_images "$1"
   run_step "$(counter)Stopping ${bold}$1${normal}" compose stop -t "$STOP_TIMEOUT"
   run_step "$(counter)Starting ${bold}$1${normal}" compose up -d
-  ok "$(counter)$1 updated and running"
+  wait_healthy "$1" "updated and running"
   record "$1" "updated"
   leave_app
 }
@@ -400,7 +474,7 @@ backup_app() {
     done
   fi
   run_step "$(counter)Starting ${bold}$1${normal}" compose up -d
-  ok "$(counter)$1 backed up, updated and running"
+  wait_healthy "$1" "backed up, updated and running"
   record "$1" "backed up"
   leave_app
 }
@@ -510,6 +584,7 @@ restore_app() {
 
   enter_app "$1"
   run_step "$(counter)Starting ${bold}$1${normal}" compose up -d
+  wait_healthy "$1" ""
   leave_app
   ok "$(counter)$1 restored. Previous data kept at ${aside##*/} - delete it once you're happy"
   record "$1" "restored"

--- a/docker_volumes/manage.sh
+++ b/docker_volumes/manage.sh
@@ -278,8 +278,82 @@ run_command() {
   esac
 }
 
+pick_app() {
+  #Sets PICKED_APP to one app name, or "" for all apps. Returns 1 if cancelled.
+  PICKED_APP=""
+  if command -v fzf >/dev/null 2>&1; then
+    PICKED_APP=$(printf '%s\n' "all apps" "$@" | fzf --prompt="app> ") || return 1
+    if [ "$PICKED_APP" = "all apps" ]; then
+      PICKED_APP=""
+    fi
+    return 0
+  fi
+  n=0
+  echo "  0) all apps"
+  for app in "$@"; do
+    n=$((n + 1))
+    echo "  $n) $app"
+  done
+  printf "Select an app [0-%s]: " "$n"
+  read -r selection || return 1
+  if [ "$selection" = "0" ]; then
+    return 0
+  fi
+  n=0
+  for app in "$@"; do
+    n=$((n + 1))
+    if [ "$n" = "$selection" ]; then
+      PICKED_APP=$app
+      return 0
+    fi
+  done
+  echo "Not a valid selection."
+  return 1
+}
+
+interactive() {
+  checkDefault
+  require_docker
+  ALL_APPS=$Apps
+  while :; do
+    echo ""
+    echo "${bold}DockerDance${normal} - what would you like to do?"
+    echo "  1) start    2) stop     3) restart"
+    echo "  4) update   5) backup   6) logs"
+    echo "  7) version  8) running  q) quit"
+    printf "> "
+    read -r choice || break
+    case "$choice" in
+      1 ) choice="start" ;;
+      2 ) choice="stop" ;;
+      3 ) choice="restart" ;;
+      4 ) choice="update" ;;
+      5 ) choice="backup" ;;
+      6 ) choice="logs" ;;
+      7 ) choice="version" ;;
+      8 ) choice="running" ;;
+      q | Q | quit | exit ) break ;;
+      * ) echo "Not a valid choice."; continue ;;
+    esac
+    Apps=$ALL_APPS
+    if [ "$choice" != "running" ]; then
+      # shellcheck disable=SC2086 # Apps is an intentionally space-separated list
+      pick_app $Apps || continue
+      if [ -n "$PICKED_APP" ]; then
+        Apps=$PICKED_APP
+      fi
+    fi
+    run_command "$choice"
+  done
+}
+
 APPS_OVERRIDDEN=0
 if [ $# -eq 0 ]; then
+  if [ -t 0 ]; then
+    #No arguments on a terminal: offer the interactive menu
+    interactive
+    exit 0
+  fi
   usage
   exit 1
 fi


### PR DESCRIPTION
## DockerDance v0.3.0 — robustness, safety and UX overhaul

A big round of improvements to `docker_volumes/manage.sh`, landing as **v0.3.0** (the first release since v0.1.0). Everything stays a single POSIX-`sh` script with **zero required dependencies**; the direct commands and cron usage are unchanged in spirit. Full detail in the new [CHANGELOG](CHANGELOG.md).

### Correctness & safety fixes (the important ones)
- **Graceful shutdown before backup.** `docker compose kill` (SIGKILL) → `docker compose stop` everywhere, so databases shut down cleanly before their volumes are tarred — `kill` risked archiving corrupt state. Adds `STOP_TIMEOUT` (default 30s) so a busy DB isn't force-killed at docker's 10s default.
- **The Docker check actually runs now.** It was unreachable under `set -e`; replaced with `command -v docker` plus a `docker info` daemon-reachability check.
- Removed a stray `exec "$@"` that ran leftover arguments as a command.
- POSIX/dash correctness: `==`→`=`, quoted path expansions, backticks→`$(...)`, `mkdir -p` the backup dir, non-blocking `logs`.
- **Safe restore.** Archives are treated as untrusted — extraction happens in an isolated staging area (never `tar -C /`), `..`-traversal/absolute members are refused, and only the app's own folder is promoted into place.

### New features
- **Zero-config discovery** — `Apps="auto"` (default) manages every folder with a compose file; drop the script in and go.
- **`restore`** (#2), **per-app targeting** (#1), **nested compose folders** (#6), **webhook notifications** via `NOTIFY_WEBHOOK` (#3).
- **`status`** dashboard and **`doctor`** environment check.
- **Health-aware start** — waits for containers to report healthy after `up -d` (`HEALTH_TIMEOUT`).
- **Parallel image pulls** for `update`/`backup` (`PARALLEL_PULLS`), pull-before-stop to minimise downtime.
- **`system-update`** — detects apt-get/dnf/yum/pacman/zypper/apk/brew (Debian, Fedora, Arch, openSUSE, Alpine, macOS); `apt` kept as an alias.
- **Interactive menu** (numbered, or fzf with multi-select + live status preview), `--dry-run`, `-y/--yes`, `--no-color`, `--version`, `update-self` (release-based), optional `manage.conf`, a run lock, backup retention (`BACKUP_KEEP`) and `chmod 600` archives.
- Colours, spinners, progress counters, a per-run summary table, and bash/zsh/fish completions.

### Repo
- `.github/workflows/shellcheck.yml` — shellcheck + dash syntax check on every push/PR (green on this branch).
- README refresh, `CHANGELOG.md`, `manage.conf.example`, `.gitignore`.

### Testing
`shellcheck` + `sh`/`dash`/`bash` syntax all clean. Because a live Docker daemon wasn't available, every feature was exercised through a pseudo-terminal harness with a stubbed `docker` CLI — graceful-stop paths, health (healthy/unhealthy/timeout), parallel-pull concurrency and failure-skip, dry-run writing nothing, restore of both archive layouts **plus a crafted path-traversal archive that is refused with the filesystem left untouched**, and the menu flows. A couple of things I couldn't verify locally and would suggest a quick check on real hardware: the `system-update` package-manager commands (stub-tested for correct invocation, not run live on each distro) and the fish completion (fish wasn't installed).

Closes #1, #2, #3, #5, #6. (#4 Dockerfile intentionally left out — the script manages host containers via the docker socket and host paths, so containerising it adds privilege complexity without benefit for the cron/alias use case; happy to revisit.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
