### PR TITLE
Put apps back the way they were found

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,53 @@
+name: Release
+
+# Pushing a v* tag publishes the release, using that version's CHANGELOG
+# section as the notes. Tagging stays the only manual step:
+#   git tag v0.4.0 && git push origin v0.4.0
+
+on:
+  push:
+    tags: ['v*']
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Tag must match manage.sh VERSION
+        run: |
+          tag_version=${GITHUB_REF_NAME#v}
+          file_version=$(sed -n 's/^VERSION="\(.*\)"$/\1/p' docker_volumes/manage.sh | head -1)
+          if [ "$tag_version" != "$file_version" ]; then
+            echo "Tag $GITHUB_REF_NAME does not match VERSION=\"$file_version\" in docker_volumes/manage.sh" >&2
+            exit 1
+          fi
+
+      # update-self downloads manage.sh at the release tag and runs it, so a
+      # broken script must never make it into a release
+      - name: ShellCheck the tagged script
+        run: |
+          shellcheck docker_volumes/manage.sh contrib/dockerdance-completion.bash
+          sh -n docker_volumes/manage.sh
+
+      - name: Take the release notes from the CHANGELOG
+        run: |
+          tag_version=${GITHUB_REF_NAME#v}
+          awk -v want="## [$tag_version]" '
+            index($0, want) == 1 { found = 1; next }
+            found && /^## \[/     { exit }
+            found                 { print }
+          ' CHANGELOG.md > release-notes.md
+          if [ ! -s release-notes.md ]; then
+            echo "CHANGELOG.md has no '## [$tag_version]' section to release from" >&2
+            exit 1
+          fi
+          cat release-notes.md
+
+      - name: Publish
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release create "$GITHUB_REF_NAME" --title "$GITHUB_REF_NAME" --notes-file release-notes.md

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -14,3 +14,17 @@ jobs:
         run: shellcheck docker_volumes/manage.sh contrib/dockerdance-completion.bash
       - name: POSIX syntax check (dash)
         run: sh -n docker_volumes/manage.sh
+      # Catches the drift where VERSION is bumped but the CHANGELOG isn't -
+      # the release workflow takes its notes from the matching section, so a
+      # missing one would only surface at tag time.
+      - name: VERSION has a CHANGELOG section
+        run: |
+          version=$(sed -n 's/^VERSION="\(.*\)"$/\1/p' docker_volumes/manage.sh | head -1)
+          if [ -z "$version" ]; then
+            echo "No VERSION= found in docker_volumes/manage.sh" >&2
+            exit 1
+          fi
+          if ! grep -qF "## [$version]" CHANGELOG.md; then
+            echo "manage.sh is at VERSION=\"$version\" but CHANGELOG.md has no '## [$version]' section" >&2
+            exit 1
+          fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,14 @@ All notable changes to DockerDance are documented here. The format follows
 [Semantic Versioning](https://semver.org/). `./manage.sh update-self` updates to
 the latest tagged release.
 
-## [0.3.0] - 2026-07-13
+To cut a release: add the section below, set `VERSION` in `manage.sh` to match,
+then push the tag (`git tag v0.4.0 && git push origin v0.4.0`). The release
+workflow publishes it using this file's section for that version as the notes.
 
-The first release since v0.1.0 - a substantial robustness, safety and UX
-overhaul. `./manage.sh update-self` will offer this to anyone on v0.1.0.
+## [0.4.0] - 2026-08-04
+
+Failure handling and feedback, largely shaped by a 30-app `update` that stopped
+dead on the first broken app and said almost nothing about the rest.
 
 ### Added
 - **Apps are put back the way they were found.** `update` and `backup` now
@@ -34,6 +38,33 @@ overhaul. `./manage.sh update-self` will offer this to anyone on v0.1.0.
   architecture, a bind-mount path the daemon can't reach, a port already
   taken, an image or tag that doesn't exist, a full disk, or a *folder*
   named `compose.yaml` shadowing the real compose file.
+- **Live progress while images pull.** The pull phase announced itself and then
+  went quiet for the whole download. The spinner now names the apps currently
+  downloading and counts them off (`[4/30]`), each app prints a line as it
+  lands or fails, and the phase closes with a total. Without a terminal
+  (cron, pipes) the same per-app lines are written as each pull finishes.
+
+### Changed
+- **Pulls keep `PARALLEL_PULLS` downloads in flight**, starting the next app
+  the moment any one finishes, rather than waiting for a whole batch of three
+  to complete before beginning the next three - one slow image no longer
+  leaves the other download slots idle.
+
+### Fixed
+- Without a terminal (cron, pipes) a failed step was never labelled as one -
+  `run_step` returned success regardless, and the run died with only docker's
+  raw output as a clue. Failures are now reported and propagated the same way
+  they are on a terminal.
+- A `PARALLEL_PULLS` of `0`, a negative or a typo left the pull orchestrator
+  with no slot it could ever fill, hanging the run; it now falls back to the
+  default of 3.
+
+## [0.3.0] - 2026-07-13
+
+The first release since v0.1.0 - a substantial robustness, safety and UX
+overhaul. `./manage.sh update-self` will offer this to anyone on v0.1.0.
+
+### Added
 - **Docker install offer.** When Docker isn't installed, commands now point to
   the official install docs and can fetch and run Docker's `get.docker.com`
   script for you after you confirm (interactive only, never in cron).
@@ -48,14 +79,8 @@ overhaul. `./manage.sh update-self` will offer this to anyone on v0.1.0.
   `restore` wait for containers to become healthy (or just running, with no
   healthcheck) before reporting done. Tunable with `HEALTH_TIMEOUT` (0 skips).
 - **Parallel image pulls.** `update` and `backup` pull all target apps'
-  images at once, keeping `PARALLEL_PULLS` (default 3) downloads in flight -
-  the next app starts the moment any one finishes, so a single slow image
-  never idles the other slots. A failed pull leaves that app on its current
-  image and is skipped rather than aborting the run.
-  The pull phase reports as it goes - the spinner names the apps currently
-  downloading and counts them off (`[4/30]`), each app prints a line as it
-  lands or fails, and the phase closes with a total. Without a terminal
-  (cron, pipes) the same per-app lines are written as each pull finishes.
+  images at once, up to `PARALLEL_PULLS` (default 3); a failed pull leaves
+  that app on its current image and is skipped rather than aborting the run.
 - **`--dry-run`** previews any command without touching anything, **`-y`/`--yes`**
   skips confirmations (and lets `restore` run non-interactively), and **update**
   now confirms before recreating containers on a terminal. **`--no-color`** flag.
@@ -119,10 +144,6 @@ overhaul. `./manage.sh update-self` will offer this to anyone on v0.1.0.
   symlink pre-creation angle when running as root.
 
 ### Fixed
-- Without a terminal (cron, pipes) a failed step was never labelled as one -
-  `run_step` returned success regardless, and the run died with only docker's
-  raw output as a clue. Failures are now reported and propagated the same way
-  they are on a terminal.
 - **Graceful shutdown before backup.** `docker compose kill` (SIGKILL) is
   replaced with `docker compose stop` everywhere, so databases shut down cleanly
   before their volumes are archived — `kill` risked backing up corrupt state.
@@ -141,5 +162,6 @@ overhaul. `./manage.sh update-self` will offer this to anyone on v0.1.0.
 - Initial release: bulk `start` / `stop` / `restart` / `update` / `backup` of
   docker-compose apps laid out in per-app folders.
 
+[0.4.0]: https://github.com/AdamXweb/DockerDance/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/AdamXweb/DockerDance/compare/v0.1.0...v0.3.0
 [0.1.0]: https://github.com/AdamXweb/DockerDance/releases/tag/v0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ The first release since v0.1.0 - a substantial robustness, safety and UX
 overhaul. `./manage.sh update-self` will offer this to anyone on v0.1.0.
 
 ### Added
+- **Apps are put back the way they were found.** `update` and `backup` now
+  check which apps are actually running before touching anything, show you
+  the split, and leave stopped apps stopped - an app you deliberately shut
+  down no longer comes back up as a side effect of updating. Its new image
+  is still pulled, so it starts current next time. On a terminal a single
+  prompt asks what to do with the stopped ones (leave them / start them too /
+  skip them entirely, with a recommendation); `--stopped=keep|start|skip`
+  (or `STOPPED_POLICY` in `manage.conf`) decides it for cron. `--stopped=start`
+  restores the old sweep-everything-up behaviour. `stop`, `start` and
+  `restart` are unchanged - those are explicit instructions, not a sweep.
 - **One bad app no longer ends the run.** A failure on a single app (its
   containers won't start, its folder is missing, its archive can't be written)
   is reported and the run carries on through the remaining apps, instead of

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Then run `./manage.sh` for the interactive menu, or `./manage.sh help` for the c
 To pin the set or the order instead, list the folders explicitly e.g. `Apps="linkace .n8n dashy"`
 `USERNAME="systemadmin"` - The user folder that you store the `docker_volumes` in. If you're stuck, type `pwd` to find the path you're in, or `whoami` to get the user name.
 `DOCKER_VOLUMES` defaults to `/home/$USERNAME/docker_volumes/` and can be overwritten in the script, or from the environment without editing anything — handy for MacOS: `DOCKER_VOLUMES="/Users/UserName/docker_volumes/" ./manage.sh start`
+`STOPPED_POLICY` (default `keep`) - what `update`/`backup` do with apps that are already stopped: `keep` leaves them stopped with their new image ready, `start` brings them up too, `skip` leaves them entirely alone. Same values as `--stopped=`.
 `STOP_TIMEOUT` (default `30`) - seconds to wait for containers to shut down gracefully before docker gives up. Raise it for databases that take a while to flush.
 `HEALTH_TIMEOUT` (default `60`) - after starting an app, seconds to wait for its containers to become healthy (or just running, if they have no healthcheck) before moving on. Set `0` to skip the wait entirely.
 `PARALLEL_PULLS` (default `3`) - how many image pulls `update`/`backup` keep in flight at once; as each one finishes the next app starts straight away. Set `1` for the old one-at-a-time behaviour.
@@ -64,9 +65,10 @@ First, make sure you are in the `docker_volumes` folder, and execute any of the 
 
 Every command runs against all the apps in the `Apps` variable by default. To target one or more specific apps, add their folder names after the command, e.g. `./manage.sh restart linkace` or `./manage.sh update linkace uptime-kuma`.
 
-Two options work with any command (before or after it):
+Options that work with any command (before or after it):
 - `--dry-run` prints exactly what would happen — which apps get pulled, stopped, backed up, started — without touching anything.
 - `-y` / `--yes` skips confirmation prompts (so `update` and `restore` can run unattended).
+- `--stopped=keep|start|skip` decides what `update` and `backup` do with apps that are already stopped — see [Keeping apps as you found them](#keeping-apps-as-you-found-them).
 - `--no-color` turns off coloured output (as does setting `NO_COLOR`).
 
 ### Interactive menu
@@ -93,7 +95,7 @@ Starts all the apps by navigating through each folder and starting with `docker 
 
 ### Update
 `./manage.sh update`
-Pulls the latest images for all target apps **in parallel** (keeping `PARALLEL_PULLS` downloads in flight), then stops and recreates each container on the new image — so downtime is just the stop/start window, not the download. The pull phase names the apps it's downloading and counts them off, printing a line per app as it lands, so a long pull across many apps shows progress rather than a silent spinner. On a terminal it asks for confirmation first (skip with `-y`); an app whose pull fails is left running on its current image and reported. After starting, it waits for each app to report healthy (see [Health](#health) below).
+Pulls the latest images for all target apps **in parallel** (keeping `PARALLEL_PULLS` downloads in flight), then stops and recreates each container on the new image — so downtime is just the stop/start window, not the download. The pull phase names the apps it's downloading and counts them off, printing a line per app as it lands, so a long pull across many apps shows progress rather than a silent spinner. Apps that are already stopped stay stopped — their image is still pulled, so they come up current next time (see [Keeping apps as you found them](#keeping-apps-as-you-found-them)). On a terminal it asks for confirmation first (skip with `-y`); an app whose pull fails is left running on its current image and reported. After starting, it waits for each app to report healthy (see [Health](#health) below).
 
 ### Restart
 `./manage.sh restart`
@@ -116,6 +118,26 @@ A dashboard with one line per app: a coloured running/stopped dot, container sta
 <a name="health"></a>
 ### Health
 After starting an app (via `start`, `restart`, `update`, `backup` or `restore`), the script waits for its containers to come up rather than just assuming they will. Containers with a healthcheck must report `healthy`; those without just need to be running. The result line becomes e.g. `linkace started, healthy`, or a warning if a container is unhealthy or still starting after `HEALTH_TIMEOUT` (default 60s; set `0` to skip the wait). The wait is best-effort and never fails the run.
+
+### Keeping apps as you found them
+`update` and `backup` check which apps are actually running before they touch anything, and put each one back the way they found it. An app you deliberately stopped is **not** started as a side effect of updating — its new image is still pulled, so it comes up current the next time you start it.
+
+You see the split up front, and on a terminal a single prompt settles the rest:
+
+```
+  ● 5 running: authelia, gitea, immich, jellyfin, nextcloud
+  ○ 3 stopped: audiobookshelf, larapaper, vaultwarden
+Update 5 running app(s). The other 3 are stopped - what should happen to them?
+  1) leave them stopped, but pull so they're current next start (recommended)
+  2) start them too, so everything ends up running
+  3) skip them entirely - no pull, no changes
+  n) cancel
+Choose [1]:
+```
+
+For cron and scripts, `--stopped=keep|start|skip` (or `STOPPED_POLICY` in `manage.conf`) picks the same three answers without prompting — as does `-y`, which takes the default. `--stopped=start` is the old behaviour, where everything ends up running.
+
+`backup` follows the same rule: a stopped app is archived where it lies, without being started to do it. `stop`, `start` and `restart` are unaffected — those are explicit instructions rather than a sweep, so `restart` on a stopped app still starts it.
 
 ### When something fails
 One bad app doesn't end the run. If an app's containers won't start, its folder is missing, or its archive can't be written, that app is reported and the run carries on through the rest. The failure is printed where it happens — the command's own output, plus a `[hint]` line when the cause is a recognisable one (an image with no build for your architecture, a bind-mount path docker can't reach, a port already taken, an image or tag that doesn't exist, a full disk, a *folder* named `compose.yaml` shadowing the real compose file).

--- a/docker_volumes/manage.sh
+++ b/docker_volumes/manage.sh
@@ -391,6 +391,122 @@ resolve_dir() {
   return 1
 }
 
+#What update/backup do with an app that is already stopped:
+#  keep  - bring its new image down but leave the app stopped (the default:
+#          an app you deliberately stopped shouldn't come back up on its own)
+#  start - update it and start it, so everything ends up running
+#  skip  - don't touch it at all, not even a pull
+#Set when the choice came from --stopped, manage.conf or the environment, so
+#the interactive prompt doesn't second-guess a preference already expressed
+STOPPED_SET=""
+[ -n "${STOPPED_POLICY:-}" ] && STOPPED_SET=1
+STOPPED_POLICY="${STOPPED_POLICY:-keep}"
+valid_stopped_policy() {
+  case "$1" in
+    keep | start | skip ) return 0 ;;
+    * ) return 1 ;;
+  esac
+}
+
+#Every running container id, fetched once so the state scan below costs one
+#docker call plus a compose ps per app, rather than an inspect per container.
+RUNNING_IDS=""
+load_running_ids() {
+  RUNNING_IDS=$(docker ps -q --no-trunc 2>/dev/null || true)
+}
+
+#True when at least one of the app's containers is running right now
+app_is_up() {
+  ai_dir=$(resolve_dir "$1") || return 1
+  ai_ids=$(cd "$ai_dir" && compose ps -q 2>/dev/null) || return 1
+  [ -n "$ai_ids" ] || return 1
+  # shellcheck disable=SC2086 # ids are one per line with no spaces
+  for ai_id in $ai_ids; do
+    printf '%s\n' "$RUNNING_IDS" | grep -qx "$ai_id" && return 0
+  done
+  return 1
+}
+
+#Split the apps into APPS_UP / APPS_DOWN before anything is changed, so the
+#run can put each one back the way it found it.
+APPS_UP=""
+APPS_DOWN=""
+scan_state() {
+  APPS_UP=""
+  APPS_DOWN=""
+  #Read-only, so it runs for --dry-run too and reports the real state
+  load_running_ids
+  for sc_app in "$@"; do
+    if app_is_up "$sc_app"; then
+      APPS_UP="$APPS_UP $sc_app"
+    else
+      APPS_DOWN="$APPS_DOWN $sc_app"
+    fi
+  done
+  APPS_UP=${APPS_UP# }
+  APPS_DOWN=${APPS_DOWN# }
+}
+
+#Show what's running before anything is touched - the state half of "see the
+#state, then put it back".
+print_state() {
+  count_list "$APPS_UP";   ps_up=$COUNTED
+  count_list "$APPS_DOWN"; ps_down=$COUNTED
+  [ "$ps_up" -gt 0 ]   && echo "  ${green}${DOT_ON}${normal} $ps_up running: $(join_list "$APPS_UP")"
+  [ "$ps_down" -gt 0 ] && echo "  ${dim}${DOT_OFF}${normal} $ps_down stopped: $(join_list "$APPS_DOWN")"
+  return 0
+}
+
+#Settle what happens to any stopped apps and, for commands that ask before
+#acting, confirm the run - one prompt does both jobs. $1 is the verb, $2 the
+#explanation for the plain y/N form, $3 is "always" to confirm even when
+#nothing is stopped (update does; backup never has), then the apps. Returns
+#non-zero if the user backs out. Without a terminal (or with -y / --stopped)
+#STOPPED_POLICY is taken as given and nothing is asked.
+confirm_run() {
+  cr_verb=$1
+  cr_detail=$2
+  cr_always=$3
+  shift 3
+  count_list "$APPS_DOWN"; cr_down=$COUNTED
+  if [ "$cr_down" -eq 0 ]; then
+    [ "$cr_always" = "always" ] || return 0
+    confirm "$cr_verb $# app(s)? $cr_detail" || return 1
+    return 0
+  fi
+  if [ -n "${ASSUME_YES:-}" ] || [ -n "$STOPPED_SET" ] || [ ! -t 0 ]; then
+    return 0
+  fi
+  count_list "$APPS_UP"; cr_up=$COUNTED
+  echo "$cr_verb $cr_up running app(s). The other $cr_down are stopped - what should happen to them?"
+  echo "  1) leave them stopped, but pull so they're current next start ${dim}(recommended)${normal}"
+  echo "  2) start them too, so everything ends up running"
+  echo "  3) skip them entirely - no pull, no changes"
+  echo "  n) cancel"
+  printf 'Choose [1]: '
+  read -r cr_ans || cr_ans=""
+  case "$cr_ans" in
+    '' | 1 | keep )  STOPPED_POLICY="keep" ;;
+    2 | start )      STOPPED_POLICY="start" ;;
+    3 | skip )       STOPPED_POLICY="skip" ;;
+    * )              return 1 ;;
+  esac
+  return 0
+}
+
+#The apps worth pulling images for: everything, minus the stopped ones when
+#the policy is to leave those completely alone.
+pull_target_list() {
+  pt_out=""
+  for pt_app in "$@"; do
+    if [ "$STOPPED_POLICY" = "skip" ] && in_list "$pt_app" "$APPS_DOWN"; then
+      continue
+    fi
+    pt_out="$pt_out $pt_app"
+  done
+  printf '%s' "${pt_out# }"
+}
+
 #Is $1 one of the space-separated words in $2?
 in_list() {
   # shellcheck disable=SC2086 # $2 is an intentionally space-separated list
@@ -450,6 +566,7 @@ print_summary() {
 #what went wrong, rather than the run stopping dead on the first failure.
 RUN_FAILED=""
 RUN_SKIPPED=""
+RUN_KEPT=""
 RUN_RESULT=""
 #$2 is the step that failed, used for the summary row
 fail_app() {
@@ -465,6 +582,21 @@ skip_app() {
   app_start=$(date +%s)
   warn "$(counter)Skipping $1 ($2)"
   record "$1" "skipped"
+  return 0
+}
+
+#The app was already stopped and the policy is to leave it that way. Its new
+#image has been pulled, and compose recreates a stopped container on the new
+#image the next time the app is started, so there's nothing else to do.
+keep_stopped_app() {
+  RUN_KEPT="$RUN_KEPT $1"
+  app_start=$(date +%s)
+  if [ -n "${DRY_RUN:-}" ]; then
+    echo "${dim}[dry-run]${normal} would leave ${bold}$1${normal} stopped, with its new image pulled and ready"
+  else
+    ok "$(counter)$1 left stopped - new image ready for its next start"
+  fi
+  record "$1" "image ready"
   return 0
 }
 
@@ -496,14 +628,18 @@ finish_run() {
   print_summary
   count_list "$RUN_FAILED";  fr_failed=$COUNTED
   count_list "$RUN_SKIPPED"; fr_skipped=$COUNTED
+  count_list "$RUN_KEPT";    fr_kept=$COUNTED
+  #Apps left stopped on purpose were handled as asked, so they count as done
   fr_done=$((APP_TOTAL - fr_failed - fr_skipped))
   fr_word="apps"
   [ "$APP_TOTAL" -eq 1 ] && fr_word="app"
+  fr_kept_note=""
+  [ "$fr_kept" -gt 0 ] && fr_kept_note=" ($fr_kept left stopped)"
   if [ "$fr_failed" -eq 0 ] && [ "$fr_skipped" -eq 0 ]; then
     if [ "$APP_TOTAL" -eq 1 ]; then
-      RUN_RESULT="$1 1 app in $(elapsed)"
+      RUN_RESULT="$1 1 app in $(elapsed)$fr_kept_note"
     else
-      RUN_RESULT="$1 all $APP_TOTAL apps in $(elapsed)"
+      RUN_RESULT="$1 all $APP_TOTAL apps in $(elapsed)$fr_kept_note"
     fi
     success "$RUN_RESULT.${2:+ $2}"
     return 0
@@ -511,7 +647,7 @@ finish_run() {
   fr_note=""
   [ "$fr_failed" -gt 0 ]  && fr_note="$fr_failed failed"
   [ "$fr_skipped" -gt 0 ] && fr_note="${fr_note:+$fr_note, }$fr_skipped skipped"
-  RUN_RESULT="$1 $fr_done of $APP_TOTAL $fr_word in $(elapsed) - $fr_note"
+  RUN_RESULT="$1 $fr_done of $APP_TOTAL $fr_word in $(elapsed) - $fr_note$fr_kept_note"
   warn "$RUN_RESULT"
   [ "$fr_failed" -gt 0 ]  && echo "  ${red}failed:${normal}  $(join_list "$RUN_FAILED")" >&2
   [ "$fr_skipped" -gt 0 ] && echo "  ${yellow}skipped:${normal} $(join_list "$RUN_SKIPPED")" >&2
@@ -814,7 +950,16 @@ update_app() {
 backup_app() {
   app_start=$(date +%s)
   enter_app "$1" || return 1
-  run_step "$(counter)Stopping ${bold}$1${normal}" compose stop -t "$STOP_TIMEOUT" || return 1
+  #An app that was already stopped is archived where it lies and left that way
+  #(unless the policy says to start everything), so a backup doesn't quietly
+  #bring up something that was deliberately down.
+  was_up=0
+  if in_list "$1" "$APPS_UP" || [ "$STOPPED_POLICY" = "start" ]; then
+    was_up=1
+  fi
+  if [ "$was_up" -eq 1 ] && in_list "$1" "$APPS_UP"; then
+    run_step "$(counter)Stopping ${bold}$1${normal}" compose stop -t "$STOP_TIMEOUT" || return 1
+  fi
   archive="${TARGET}${1}$(date '+%Y-%m-%d').tar.bz2"
   if [ -z "${DRY_RUN:-}" ]; then
     mkdir -p "$TARGET"
@@ -837,16 +982,25 @@ backup_app() {
       done
     fi
   fi
-  #Start the app again even when the archive failed - a bad backup mustn't
-  #leave the app sitting stopped
-  run_step "$(counter)Starting ${bold}$1${normal}" compose up -d || return 1
+  #Put the app back the way it was found. Starting happens even when the
+  #archive failed - a bad backup mustn't leave a running app stopped.
+  if [ "$was_up" -eq 1 ]; then
+    run_step "$(counter)Starting ${bold}$1${normal}" compose up -d || return 1
+  fi
   if [ "$archive_status" -ne 0 ]; then
     rm -f "$archive"
-    warn "$(counter)$1 is running again, but it has no new backup"
+    warn "$(counter)$1 is back as it was, but it has no new backup"
     return 1
   fi
-  wait_healthy "$1" "backed up, updated and running"
-  record "$1" "backed up"
+  if [ "$was_up" -eq 1 ]; then
+    wait_healthy "$1" "backed up, updated and running"
+    record "$1" "backed up"
+  else
+    #wait_healthy would normally carry this line, but there's nothing to wait for
+    [ -z "${DRY_RUN:-}" ] && ok "$(counter)$1 backed up, left stopped"
+    RUN_KEPT="$RUN_KEPT $1"
+    record "$1" "backed up"
+  fi
   leave_app
 }
 
@@ -1224,6 +1378,9 @@ Commands:
 Options:
   --dry-run    Show what each command would do without touching anything
   -y, --yes    Don't prompt for confirmation (update / restore)
+  --stopped=X  What update/backup do with apps that are already stopped:
+               keep (default) leaves them stopped with their new image ready,
+               start brings them up too, skip leaves them entirely alone
   --no-color   Disable coloured output
 
 Commands run against every app in the Apps variable. The default, "auto",
@@ -1245,6 +1402,7 @@ run_command() {
   SUMMARY=""
   RUN_FAILED=""
   RUN_SKIPPED=""
+  RUN_KEPT=""
   RUN_RESULT=""
   run_status=0
   case "$menu_command" in
@@ -1258,9 +1416,21 @@ run_command() {
       NOTIFY_CONTEXT="Backup of $*"
       actioninfo "${bold}Backing up${normal} apps including:"
       list_apps "$@"
-      parallel_pull "$@"
+      scan_state "$@"
+      print_state
+      if [ -z "${DRY_RUN:-}" ] && ! confirm_run "Back up" "" stopped-only "$@"; then
+        echo "Cancelled."
+        return 0
+      fi
+      pull_targets=$(pull_target_list "$@")
+      # shellcheck disable=SC2086 # app names are space-separated with no embedded spaces
+      parallel_pull $pull_targets
       for app in "$@"; do
         APP_NUM=$((APP_NUM + 1))
+        if [ "$STOPPED_POLICY" = "skip" ] && in_list "$app" "$APPS_DOWN"; then
+          skip_app "$app" "it's stopped"
+          continue
+        fi
         if in_list "$app" "$PULL_FAILED"; then
           skip_app "$app" "its pull failed"
           continue
@@ -1305,18 +1475,30 @@ run_command() {
     'update' )
       checkDefault
       require_docker
-      if [ -z "${DRY_RUN:-}" ] && ! confirm "Update $# app(s)? This pulls new images and recreates their containers."; then
+      NOTIFY_CONTEXT="Update of $*"
+      actioninfo "${bold}Updating${normal} apps:"
+      list_apps "$@"
+      scan_state "$@"
+      print_state
+      if [ -z "${DRY_RUN:-}" ] && ! confirm_run "Update" "This pulls new images and recreates their containers." always "$@"; then
         echo "Cancelled."
         return 0
       fi
-      NOTIFY_CONTEXT="Update of $*"
-      actioninfo "${bold}Updating all services.${normal}"
-      list_apps "$@"
-      parallel_pull "$@"
+      pull_targets=$(pull_target_list "$@")
+      # shellcheck disable=SC2086 # app names are space-separated with no embedded spaces
+      parallel_pull $pull_targets
       for app in "$@"; do
         APP_NUM=$((APP_NUM + 1))
+        if [ "$STOPPED_POLICY" = "skip" ] && in_list "$app" "$APPS_DOWN"; then
+          skip_app "$app" "it's stopped"
+          continue
+        fi
         if in_list "$app" "$PULL_FAILED"; then
           skip_app "$app" "its pull failed"
+          continue
+        fi
+        if [ "$STOPPED_POLICY" = "keep" ] && in_list "$app" "$APPS_DOWN"; then
+          keep_stopped_app "$app"
           continue
         fi
         update_app "$app" || fail_app "$app"
@@ -1565,10 +1747,15 @@ for arg in "$@"; do
   case "$arg" in
     -y | --yes ) ASSUME_YES=1 ;;
     --dry-run ) DRY_RUN=1 ;;
+    --stopped=* ) STOPPED_POLICY=${arg#--stopped=}; STOPPED_SET=1 ;;
     --no-color ) bold=""; normal=""; red=""; green=""; yellow=""; cyan=""; dim="" ;;
     * ) positional="$positional $arg" ;;
   esac
 done
+if ! valid_stopped_policy "$STOPPED_POLICY"; then
+  error "--stopped must be one of: keep, start, skip (got '$STOPPED_POLICY')"
+  exit 1
+fi
 # shellcheck disable=SC2086 # app names are space-separated with no embedded spaces
 set -- $positional
 


### PR DESCRIPTION
Follow-up to #10, rebased on `main` (0.4.0).

## The problem

`update` and `backup` stopped and started every app unconditionally. An app you had deliberately shut down came back up as a side effect of updating — and there was no way to see, before committing to a run, what was actually running in the first place.

## What changed

Both commands now scan the current state first, print the split, and put each app back the way they found it:

```
[action] ⇒ Updating apps:
  ● 5 running: authelia, gitea, immich, jellyfin, nextcloud
  ○ 3 stopped: audiobookshelf, larapaper, vaultwarden
```

A stopped app still gets its new image pulled — compose recreates a stopped container on the new image at its next start — but nothing starts it. `backup` archives a stopped app where it lies instead of starting it to do so.

On a terminal, one prompt settles the rest. It doubles as `update`'s existing confirmation, so it isn't an extra question:

```
Update 5 running app(s). The other 3 are stopped - what should happen to them?
  1) leave them stopped, but pull so they're current next start (recommended)
  2) start them too, so everything ends up running
  3) skip them entirely - no pull, no changes
  n) cancel
Choose [1]:
```

For cron and scripts, `--stopped=keep|start|skip` (or `STOPPED_POLICY` in `manage.conf`) answers it without prompting, as does `-y`, which takes the default. **`--stopped=start` is the old behaviour** if you want everything swept up. With `skip`, stopped apps aren't even pulled.

The closing tally notes what was left alone:

```
[success] - Updated all 8 apps in 4s (3 left stopped).
```

### Scope

- `stop`, `start` and `restart` are untouched — those are explicit instructions rather than a sweep, so `restart` on a stopped app still starts it.
- `backup` gains no confirmation prompt it didn't have before. The stopped-apps question is the only thing it asks, and only when something is actually stopped.
- `restore` is unchanged; it's a deliberate single-app operation whose whole point is getting the app running on restored data.

### Cost of the scan

One `docker ps -q --no-trunc` for the whole run, plus a `compose ps -q` per app, with container liveness resolved by set membership rather than an `inspect` per container. I used the authoritative compose lookup rather than matching compose project labels, because a wrong reading here decides whether an app gets started.

## Verification

Against a stub `docker` modelling 8 apps — 5 running, 3 stopped — asserting on the actual `stop`/`up`/`pull` calls made, not just the output:

| case | containers cycled | images pulled |
|---|---|---|
| default (`keep`) | the 5 running only | all 8 |
| `--stopped=start` | all 8 | all 8 |
| `--stopped=skip` | the 5 running only | 5 |
| interactive `1`/Enter | the 5 running only | all 8 |
| interactive `2` | all 8 | all 8 |
| interactive `3` | the 5 running only | 5 |
| interactive `n` | none | none |

Interactive cases were driven through a real pty. Also checked: `backup` archives a stopped app without starting it (`STOP:authelia UP:authelia` and nothing else) and reports `backed up, left stopped`; `--stopped=banana` is rejected; `--dry-run` reports true state and per-app intent; `restart` on a stopped app still cycles it; and the #10 failure-mix regression still reports `6 of 10 apps - 2 failed, 2 skipped` and exits 1.

Run under Debian `dash` and Alpine busybox `ash`, with and without a pty. `shellcheck` clean, `sh -n` and `dash -n` pass.

---

# Second commit: changelog split + release automation

Nothing automated the changelog or the release, so `main` had drifted: `manage.sh` was bumped to `VERSION="0.4.0"` while the CHANGELOG's top heading was still `## [0.3.0] - 2026-07-13`, and everything merged since the July 0.3.0 release sat under that heading. With no `v0.4.0` tag, `update-self` also still reports "already up to date" for everyone, however much has landed on main.

## Changelog

Split at the `v0.3.0` tag, using `git log v0.3.0..main` rather than guesswork. **0.3.0 keeps only what it shipped** — including its original *"up to `PARALLEL_PULLS` at a time"* pull entry, which I'd edited in place in #9 to describe work that came later. That was wrong of me: 0.3.0's release notes are published and don't include it.

A new **0.4.0** section collects what actually landed after the release: live pull progress, sliding-window pulls, carrying on past a failed app, the failure hints, and the state-preserving update. Dated today — adjust if you tag later; the release workflow matches on version, not date.

## Release workflow

`.github/workflows/release.yml`, on a `v*` tag push. Tagging stays the only manual step:

```bash
git tag v0.4.0 && git push origin v0.4.0
```

It then: checks the tag matches `VERSION` in `manage.sh`; shellchecks the tagged script (`update-self` downloads and runs this exact file, so a broken one must never reach a release); extracts that version's CHANGELOG section; and publishes the release with it as the notes.

The Lint workflow also gains a step failing any PR where `VERSION` has no matching CHANGELOG heading — the drift that started this. It ran green on this PR.

### Checked

Both workflows parse as YAML and every `run:` block passes `sh -n`. The extraction was run against the real file: 49 lines for 0.4.0, correctly bounded at the `## [0.3.0]` heading; 0.3.0 still bounded at `## [0.1.0]`; a nonexistent version yields 0 bytes so the workflow fails rather than publishing empty notes; and the new intro paragraph doesn't leak into the extracted notes. The tag guard accepts `v0.4.0` and rejects `v0.5.0` against `VERSION="0.4.0"`.

I couldn't exercise the publish step itself without pushing a tag to your repo, which is yours to do.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
