### PR TITLE
chore: justfile + license maintenance

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022 Adam Kostarelas
+Copyright (c) 2022-2026 Adam Kostarelas
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/justfile
+++ b/justfile
@@ -1,0 +1,25 @@
+# List available commands
+default:
+    @just --list
+
+# Run the POSIX test harness (stub docker, no daemon touched)
+[group("dev")]
+test:
+    sh tests/run-tests.sh
+
+# ShellCheck and POSIX syntax check, same targets as CI
+[group("dev")]
+lint:
+    shellcheck docker_volumes/manage.sh contrib/dockerdance-completion.bash tests/run-tests.sh tests/stub/docker
+    sh -n docker_volumes/manage.sh
+
+# Run the management script's interactive menu
+[group("dev")]
+run:
+    sh docker_volumes/manage.sh
+
+# Tag and push a release (release.yml attaches manage.sh and its checksum)
+[group("ship")]
+release version:
+    git tag -a v{{version}} -m v{{version}}
+    git push origin v{{version}}


### PR DESCRIPTION
Adds a justfile delegating to the repo's real commands (POSIX test harness, the shellcheck.yml lint targets, tag-push release matching release.yml). Extends the existing MIT copyright year from 2022 to 2022-2026 (holder already correct). Opened from the adamXbot fork — the authenticated token has no push access to AdamXweb.

`just --list` output:
```
Available recipes:
    default         # List available commands

    [dev]
    lint            # ShellCheck and POSIX syntax check, same targets as CI
    run             # Run the management script's interactive menu
    test            # Run the POSIX test harness (stub docker, no daemon touched)

    [ship]
    release version # Tag and push a release (release.yml attaches manage.sh and its checksum)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)