### PR TITLE
docs: rewrite README to the portfolio standard

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,63 @@
+# Contributing
+
+Thanks for taking a look. Issues and pull requests are welcome — there are
+[issue templates](.github/ISSUE_TEMPLATE) for bugs, feature requests and general
+feedback. The output of `./manage.sh doctor` makes a bug report much easier to
+act on.
+
+## What you need
+
+- A POSIX shell. `manage.sh` is plain POSIX `sh`, not bash — please keep it that
+  way; CI syntax-checks it with `dash`.
+- [ShellCheck](https://www.shellcheck.net) for linting.
+- `bzip2`, because backup archives are `.tar.bz2` and the round-trip tests need
+  it.
+- [`just`](https://github.com/casey/just) is optional; the
+  [`justfile`](justfile) is a shortcut for the commands below.
+
+No docker daemon is needed to run the tests — the harness uses the stub in
+[`tests/stub/docker`](tests/stub/docker).
+
+## Tests and linting
+
+```
+sh tests/run-tests.sh        # or: just test
+sh tests/run-tests.sh -v     # also show each case's captured output
+```
+
+Each case builds a fresh sandbox of fake app folders, runs `manage.sh` against
+it, and asserts on the exit status, the output, and the exact docker actions the
+stub recorded.
+
+Linting, the same targets CI uses:
+
+```
+shellcheck docker_volumes/manage.sh contrib/dockerdance-completion.bash tests/run-tests.sh tests/stub/docker
+sh -n docker_volumes/manage.sh
+# or: just lint
+```
+
+## CI
+
+[`.github/workflows/shellcheck.yml`](.github/workflows/shellcheck.yml) runs on
+pushes to `main` and on pull requests. It runs ShellCheck, the `dash` syntax
+check and the test harness, and then checks that the `VERSION` set in
+`manage.sh` has a matching `## [VERSION]` section in
+[`CHANGELOG.md`](CHANGELOG.md) — that drift would otherwise only surface at tag
+time, because the release workflow takes its notes from that section.
+
+## Releasing
+
+Add the CHANGELOG section, set `VERSION` in `docker_volumes/manage.sh` to match,
+then push the tag:
+
+```
+git tag -a v0.5.0 -m v0.5.0 && git push origin v0.5.0
+# or: just release 0.5.0
+```
+
+[`.github/workflows/release.yml`](.github/workflows/release.yml) attaches
+`manage.sh` and its `.sha256` to that version's release. Writing the release in
+the GitHub UI first also works — the workflow adds the files and leaves your
+title and notes alone. Re-running is safe: assets are replaced, notes are never
+rewritten.

--- a/README.md
+++ b/README.md
@@ -1,273 +1,111 @@
 <p align="center">
     <img width="120" src="https://user-images.githubusercontent.com/6800453/178521052-0455c0d3-cf6c-4cea-9633-db0b7853c57b.svg?raw=true">
-    <h1 align="center">Docker Dance</h1>
 </p>
+
+<h1 align="center">DockerDance</h1>
+
+<p align="center">A single POSIX shell script that bulk-manages the docker compose apps in your <code>docker_volumes</code> folder — start, stop, update, back up and restore, one folder at a time.</p>
+
 <p align="center">
     <img width="500" src="https://user-images.githubusercontent.com/6800453/178521272-3639e416-8915-4f21-9d7e-4f484852c839.gif?raw=true">
 </p>
 
+[![Project status](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2FAdamXweb%2F.github%2Fmain%2Fbadges%2FDockerDance.json)](https://github.com/AdamXweb/.github/blob/main/STATUS.md#dockerdance)
+[![Release](https://img.shields.io/github/v/release/AdamXweb/DockerDance?sort=semver)](https://github.com/AdamXweb/DockerDance/releases)
+[![Lint](https://github.com/AdamXweb/DockerDance/actions/workflows/shellcheck.yml/badge.svg?branch=main)](https://github.com/AdamXweb/DockerDance/actions/workflows/shellcheck.yml)
+[![Licence](https://img.shields.io/github/license/AdamXweb/DockerDance)](LICENSE)
 
+<!-- disclosure:start -->
+> [!WARNING]
+> **Pre-1.0 — no stable release yet.** Anything can change in any release, including a patch: APIs, CLI flags, config keys, file formats, and data already on disk. Keep your own backups.
+> **Project status.** The badge above is generated from [my status list](https://github.com/AdamXweb/.github/blob/main/STATUS.md), which says what I promise for this project and every other one.
+<!-- disclosure:end -->
 
-My Docker management scripts and structures from a homelab *enthusiast*.
-This script allows you to **bulk manage** services that have been setup by `docker compose` in folders.
+---
 
+I self-host a growing list of apps, each in its own folder with its own compose
+file, and wanted one command to sweep across all of them. The tools I found were
+heavier than the job needed, so this is the lightweight version: one file,
+`manage.sh`, that drops into your `docker_volumes` folder and works out the rest.
+It is plain POSIX `sh` with no dependencies beyond docker itself;
+[fzf](https://github.com/junegunn/fzf) is used for the interactive picker if you
+have it, and skipped if you do not.
 
-## What this does
-I wanted a script to help me manage the growing list of apps i've been self-hosting.
-There are tools out there that can help with this, however I was unable to find any that were lightweight.
-This provides an easier way to update, restart and backup apps/services.
+## What it does
 
-## Getting started
+- **Sweeps every app, or the ones you name.** `Apps="auto"` (the default)
+  discovers every folder containing a compose file, so there is no list to keep
+  up to date. `./manage.sh update linkace uptime-kuma` targets specific ones.
+- **Leaves deliberately-stopped apps stopped.** `update` and `backup` check what
+  is actually running first and put each app back the way they found it. A
+  stopped app still gets its new image pulled, so it comes up current next time
+  you start it. `--stopped=keep|start|skip` (or `STOPPED_POLICY`) makes that
+  choice explicit for cron.
+- **Updates with the downtime you would expect.** Images are pulled in parallel
+  while the apps keep running, and only then is each container stopped and
+  recreated — so downtime is the stop/start window, not the download.
+- **Backs up and restores whole app folders.** `backup` pulls, stops, tars the
+  folder into `backup/`, and starts the app again. Archives are `chmod 600`
+  because they contain your `.env`, and hold relative paths so they are
+  portable. `restore` moves your current folder aside instead of deleting it,
+  and refuses archives containing path-traversal members.
+- **Carries on when one app breaks.** A failing app is reported, often with a
+  `[hint]` at the likely cause, and the run continues. Each run ends with a
+  per-app table and a tally, and exits non-zero if anything failed, was skipped
+  or came up unhealthy.
+- **Waits for health.** After starting an app, containers with a healthcheck
+  must report `healthy` and those without must be running, up to
+  `HEALTH_TIMEOUT`.
+- **Runs fine unattended.** No terminal needed, no colour when it is not wanted,
+  a lock so a cron backup cannot overlap a manual update, and an optional
+  Slack/Discord webhook when a run finishes or fails.
 
-### Prerequisites
-- A Unix-like operating system: macOS, Linux, BSD. On Windows: WSL2 is preferred, but cygwin or msys also mostly work.
-- Docker, either with old compose (`docker-compose`) or the updated compose plugin (`docker compose`) — the script detects which you have. If Docker isn't installed, running any command points you to the [official installer](https://docs.docker.com/engine/install/) and can fetch and run Docker's `get.docker.com` script for you (after you confirm)
-- Each service contained in a folder within a `docker_volumes` folder, with its own compose file (`docker-compose.yml`/`.yaml` or `compose.yml`/`.yaml`). The script finds these folders for you (see `Apps="auto"` below)
-- Optional: [fzf](https://github.com/junegunn/fzf) for a fuzzy app-picker in the interactive menu — the menu works without it
+Full command reference: [docs/commands.md](docs/commands.md). Settings, folder
+layout and cron: [docs/configuration.md](docs/configuration.md).
 
-### Basic Usage
-The folders have been setup for use on a new server to make use of the script's structure.
-If you are starting on a new server, you can clone the contents of this repo directly into your user folder with 
-`git clone https://github.com/AdamXweb/DockerDance.git .`
+## Get it
 
-### Installing the script
-DockerDance is just the single `manage.sh` file. Download it **into your `docker_volumes` folder** and make it executable — it's a good idea to inspect a script from a project you don't yet know first, so grab it, read through it, then run it:
+DockerDance is the single `manage.sh` file. Download it **into your
+`docker_volumes` folder** and make it executable. It is worth reading a script
+from a project you do not yet know before you run it, so fetch it, read it, then
+run it:
 
-| Method    | Command (run from inside your `docker_volumes` folder)                                            |
-| :-------- | :------------------------------------------------------------------------------------------------ |
-| **curl**  | `curl -fsSL https://raw.githubusercontent.com/AdamXweb/DockerDance/main/docker_volumes/manage.sh -o manage.sh && chmod +x manage.sh` |
-| **wget**  | `wget -O manage.sh https://raw.githubusercontent.com/AdamXweb/DockerDance/main/docker_volumes/manage.sh && chmod +x manage.sh` |
-
-Then run `./manage.sh` for the interactive menu, or `./manage.sh help` for the command list. You can also pin a specific version [from the releases](https://github.com/AdamXweb/DockerDance/releases) — from v0.4.1 each release carries `manage.sh` and a `manage.sh.sha256` you can check it against; `./manage.sh update-self` updates it to the latest release later. (Prefer git? `git clone https://github.com/AdamXweb/DockerDance.git .` into your user folder gives you the whole `docker_volumes` layout.)
-
-
-#### Customise variables
-`Apps="auto"` (the default) - the script discovers every folder within `docker_volumes` that contains a compose file (`docker-compose.yml`/`.yaml` or `compose.yml`/`.yaml`, or one folder deeper) and manages all of them, in alphabetical order. The `backup` folder and `*.pre-restore.*` folders are skipped. Just drop `manage.sh` into your `docker_volumes` folder and it works.
-To pin the set or the order instead, list the folders explicitly e.g. `Apps="linkace .n8n dashy"`
-`USERNAME="systemadmin"` - The user folder that you store the `docker_volumes` in. If you're stuck, type `pwd` to find the path you're in, or `whoami` to get the user name.
-`DOCKER_VOLUMES` defaults to `/home/$USERNAME/docker_volumes/` and can be overwritten in the script, or from the environment without editing anything — handy for MacOS: `DOCKER_VOLUMES="/Users/UserName/docker_volumes/" ./manage.sh start`
-`STOPPED_POLICY` (default `keep`) - what `update`/`backup` do with apps that are already stopped: `keep` leaves them stopped with their new image ready, `start` brings them up too, `skip` leaves them entirely alone. Same values as `--stopped=`.
-`STOP_TIMEOUT` (default `30`) - seconds to wait for containers to shut down gracefully before docker gives up. Raise it for databases that take a while to flush.
-`HEALTH_TIMEOUT` (default `60`) - after starting an app, seconds to wait for its containers to become healthy (or just running, if they have no healthcheck) before moving on. Set `0` to skip the wait entirely.
-`PARALLEL_PULLS` (default `3`) - how many image pulls `update`/`backup` keep in flight at once; as each one finishes the next app starts straight away. Set `1` for the old one-at-a-time behaviour.
-`BACKUP_KEEP` (unset by default) - when set to a number, only that many most-recent backup archives are kept per app; older ones are pruned after each backup.
-`PRUNE_AFTER_UPDATE` (unset by default) - set `1` to remove dangling images after every update, reclaiming the space the old images occupied (same as passing `--prune`).
-
-`NOTIFY_WEBHOOK` (unset by default) - a webhook URL (Slack and Discord formats both work) that gets a message when an update, backup or restore completes or fails. Handy for cron runs. See issue [#3](https://github.com/AdamXweb/DockerDance/issues/3).
-
-Instead of editing the script, all of the above can live in a `manage.conf` file next to `manage.sh` (plain shell assignments, e.g. `Apps="linkace n8n"`). Settings there survive `update-self`.
-
-
-## Commands
-There are a few commands you can use with the script.
-Side note, the script executes commands in the order they are listed as e.g. `Apps="1 2 3"` iterates in that order (with `Apps="auto"` the discovered folders run alphabetically)
-
-First, make sure you are in the `docker_volumes` folder, and execute any of the commands below.
-
-Every command runs against all the apps in the `Apps` variable by default. To target one or more specific apps, add their folder names after the command, e.g. `./manage.sh restart linkace` or `./manage.sh update linkace uptime-kuma`.
-
-Options that work with any command (before or after it):
-- `--dry-run` prints exactly what would happen — which apps get pulled, stopped, backed up, started — without touching anything.
-- `-y` / `--yes` skips confirmation prompts (so `update` and `restore` can run unattended).
-- `--stopped=keep|start|skip` decides what `update` and `backup` do with apps that are already stopped — see [Keeping apps as you found them](#keeping-apps-as-you-found-them).
-- `--prune` removes dangling images after an update; `--backup-first` archives each app before it moves to its new image.
-- `--no-color` turns off coloured output (as does setting `NO_COLOR`).
-
-### Interactive menu
-`./manage.sh`
-
-Running the script with no arguments on a terminal opens a menu: pick a command (including `status`, `doctor`, `system-update` and `update-self`), then pick the app(s).
-
-- **With [fzf](https://github.com/junegunn/fzf)** the whole menu is navigable with the **arrow keys** and type-to-filter. On the command list, `Enter` selects and `Esc` quits. On the app list, `TAB` multi-selects (with a live container-status preview pane), `Enter` confirms and `Esc` goes back to the command list.
-- **Without fzf** a numbered menu is shown — type the number *or* the command name; on the app list enter a space/comma-separated list like `1 3` (or `0` for all), and `b` goes back. (Arrow-key navigation needs fzf; a `brew install fzf` / `apt install fzf` .)
-
-No extra dependencies are required either way. Cron and piped usage are unaffected: without a terminal the script prints usage instead of waiting for input.
-
-Colours and spinners appear only on capable terminals and respect [`NO_COLOR`](https://no-color.org). Only one state-changing run is allowed at a time per folder (a lock protects a cron backup from overlapping a manual update). Tab-completion is available for bash, zsh and fish in [contrib/](contrib/).
-
-### Stop
-`./manage.sh stop`
-
-Stops all the apps by navigating through each folder and stopping them gracefully with `docker compose stop`, giving databases time to finish writing before shutdown
-
-### Start
-`./manage.sh start`
-
-Starts all the apps by navigating through each folder and starting with `docker compose up -d`
-
-### Update
-`./manage.sh update`
-Pulls the latest images for all target apps **in parallel** (keeping `PARALLEL_PULLS` downloads in flight), then stops and recreates each container on the new image — so downtime is just the stop/start window, not the download. The pull phase names the apps it's downloading and counts them off, printing a line per app as it lands, so a long pull across many apps shows progress rather than a silent spinner. Apps that are already stopped stay stopped — their image is still pulled, so they come up current next time (see [Keeping apps as you found them](#keeping-apps-as-you-found-them)). On a terminal it asks for confirmation first (skip with `-y`); an app whose pull fails is left running on its current image and reported. After starting, it waits for each app to report healthy (see [Health](#health) below). Add `--backup-first` to archive every app on the way through (the backup flow already restarts each app on its freshly pulled image), and `--prune` to reclaim the old images afterwards.
-
-### Restart
-`./manage.sh restart`
-Stops all the apps, then starts them up again.
-
-### Backup
-`./manage.sh backup`
-An all-in-one per app: it pulls the latest images **while the app is still running**, stops it gracefully, tars its folder into the `backup` folder, then starts it back up on the new images. Archives are written with `chmod 600` (they contain your `.env` secrets) and store paths relative to `docker_volumes`, so a `restore` is portable. A second backup gets a `_HHMMSS` suffix. Set `BACKUP_KEEP=N` to keep only the newest N archives per app.
-
-### Restore
-`./manage.sh restore linkace`
-`./manage.sh restore linkace 2026-08-01`
-
-Puts the newest backup archive for the app back in place: stops the app, moves the current folder aside to `<app>.pre-restore.<timestamp>` (nothing is deleted), extracts the archive, and starts the app again. Asks for confirmation (needs a terminal, or pass `-y`). Older v0.1.0-era archives (absolute paths) are detected and restored too. Archives are treated as untrusted: extraction happens in an isolated staging area, any path-traversal (`..`) member is refused, and only the app's own folder is promoted — a tampered archive can't write elsewhere on disk.
-
-### Status
-`./manage.sh status`
-
-A dashboard with one line per app: a coloured running/stopped dot, container state (`up` / `N/M up` / `stopped`), the image in use, and health. Read-only — a quick "is everything OK?" at a glance.
-
-<a name="health"></a>
-### Health
-After starting an app (via `start`, `restart`, `update`, `backup` or `restore`), the script waits for its containers to come up rather than just assuming they will. Containers with a healthcheck must report `healthy`; those without just need to be running. The result line becomes e.g. `linkace started, healthy`, or a warning if a container is unhealthy or still starting after `HEALTH_TIMEOUT` (default 60s; set `0` to skip the wait). The wait is best-effort and never fails the run.
-
-### Keeping apps as you found them
-`update` and `backup` check which apps are actually running before they touch anything, and put each one back the way they found it. An app you deliberately stopped is **not** started as a side effect of updating — its new image is still pulled, so it comes up current the next time you start it.
-
-You see the split up front, and on a terminal a single prompt settles the rest:
-
-```
-  ● 5 running: authelia, gitea, immich, jellyfin, nextcloud
-  ○ 3 stopped: audiobookshelf, larapaper, vaultwarden
-Update 5 running app(s). The other 3 are stopped - what should happen to them?
-  1) leave them stopped, but pull so they're current next start (recommended)
-  2) start them too, so everything ends up running
-  3) skip them entirely - no pull, no changes
-  n) cancel
-Choose [1]:
+```sh
+# run from inside your docker_volumes folder
+curl -fsSL https://raw.githubusercontent.com/AdamXweb/DockerDance/main/docker_volumes/manage.sh -o manage.sh && chmod +x manage.sh
 ```
 
-For cron and scripts, `--stopped=keep|start|skip` (or `STOPPED_POLICY` in `manage.conf`) picks the same three answers without prompting — as does `-y`, which takes the default. `--stopped=start` is the old behaviour, where everything ends up running.
-
-`backup` follows the same rule: a stopped app is archived where it lies, without being started to do it. `stop`, `start` and `restart` are unaffected — those are explicit instructions rather than a sweep, so `restart` on a stopped app still starts it.
-
-### When something fails
-One bad app doesn't end the run. If an app's containers won't start, its folder is missing, or its archive can't be written, that app is reported and the run carries on through the rest. The failure is printed where it happens — the command's own output, plus a `[hint]` line when the cause is a recognisable one (an image with no build for your architecture, a bind-mount path docker can't reach, a port already taken, an image or tag that doesn't exist, a full disk, a *folder* named `compose.yaml` shadowing the real compose file).
-
-Every run then closes with a per-app table and a tally of what actually made it:
-
-```
-  ● authelia                 updated         4s
-  ○ audiobookshelf           failed         12s
-  ○ larapaper                skipped         0s
-[warn] - Updated 27 of 30 apps in 3m 4s - 1 failed, 2 skipped
-  failed:  audiobookshelf, vaultwarden
-  skipped: larapaper, pinchflat-X
+```sh
+wget -O manage.sh https://raw.githubusercontent.com/AdamXweb/DockerDance/main/docker_volumes/manage.sh && chmod +x manage.sh
 ```
 
-`skipped` means the app was left untouched (its image pull failed, so it stays on the image it has); `failed` means the command was attempted and didn't work; `unhealthy` means the app started on its new image but never reported healthy within `HEALTH_TIMEOUT`. The script exits non-zero when any of those buckets is non-empty, so a cron job or wrapper script can tell without parsing the output. A `backup` whose archive fails still starts the app back up rather than leaving it stopped.
+Then `./manage.sh` for the interactive menu, or `./manage.sh help` for the
+command list. `./manage.sh doctor` checks your environment without changing
+anything.
 
-#### Minor commands
-`./manage.sh version`
-Display versions of images: `docker compose images`
+You can also pin a version [from the releases](https://github.com/AdamXweb/DockerDance/releases) —
+releases from v0.4.0 carry `manage.sh` and a `manage.sh.sha256` to check it
+against — and `./manage.sh update-self` moves you to the latest release later.
+Prefer git? Cloning this repo into your user folder
+(`git clone https://github.com/AdamXweb/DockerDance.git .`) gives you the whole
+`docker_volumes` layout, including an `example` app to try a first `start`
+against.
 
-`./manage.sh doctor`
-A read-only environment check: docker daemon reachability, the compose flavour in use, whether `curl`/`wget`/`fzf` are present, the package manager `system-update` would use, `tar` safety, whether `DOCKER_VOLUMES` is writable, `manage.conf`, a stale lock, the effective settings and the discovered app list. Handy for first-run setup and bug reports.
+You need a Unix-like system (macOS, Linux, BSD; on Windows, WSL2), docker with
+either `docker compose` or `docker-compose` — the script detects which — and each
+service in its own folder under `docker_volumes` with its own compose file. If
+docker is missing, the script points you at the
+[official installer](https://docs.docker.com/engine/install/). Settings go in a
+`manage.conf` next to the script, where they survive `update-self`; see
+[docker_volumes/manage.conf.example](docker_volumes/manage.conf.example).
 
-`./manage.sh system-update`
-Updates the host OS packages with whatever package manager the system has — `apt-get` (Debian/Ubuntu), `dnf` (Fedora/RHEL), `yum`, `pacman` (Arch), `zypper` (openSUSE), `apk` (Alpine) or `brew` (macOS) — detected in that order. Distro managers need root (it tells you to `sudo`); Homebrew refuses root and must run as your normal user. `./manage.sh apt` still works as an alias.
+## Contributing
 
-`./manage.sh logs`
-Shows the recent logs for each app. When a single app is targeted (e.g. `./manage.sh logs linkace`) the log is followed live with `-f` — press Ctrl-C to stop.
+Issues and pull requests are welcome — see [CONTRIBUTING.md](CONTRIBUTING.md)
+for the test harness, linting and the release process, and
+[docs/troubleshooting.md](docs/troubleshooting.md) when something misbehaves.
+[CHANGELOG.md](CHANGELOG.md) records what has landed.
 
-`./manage.sh help`
-Show usage and the full list of commands. `./manage.sh --version` prints the script version.
+## Licence
 
-`./manage.sh update-self`
-Updates the script itself to the latest [GitHub release](https://github.com/AdamXweb/DockerDance/releases): downloads `manage.sh` at the release tag, syntax-checks it, carries your `Apps`/`USERNAME` settings over, and swaps it in place. (Use `manage.conf` for configuration and there's nothing to carry over.)
-
-
-
-## Environment
-This script is meant to run on a Unix-like system as a user with privileges to modify the app files — i.e. root, or a user whose group can read the volume data — so that backing up database files created by root doesn't fail with a permission error.
-
-> **A note on secrets and safety.** App folders usually contain a `.env` with credentials, so the backup archives do too — they're written `chmod 600` (owner-only), and the `backup` folder inherits the permissions of the root-owned `docker_volumes` tree. `restore` never deletes your current data: it moves it aside to `<app>.pre-restore.<timestamp>` and asks for confirmation before extracting. If you sync backups off-box (see below), treat that copy as sensitive too.
-
-### Folder structure
-The default path is set to `~/docker_volumes` (userhome/docker_volumes).
-Each service/app has its own folder and `docker-compose.yml` to go with it.
-For example: If i'm running [LinkAce](https://github.com/Kovah/LinkAce) I'd have the following folder structure:
-I'd also have a volume mount to the folder `data` below. `./data:/app
-```
-userfolder
-│
-└───docker_volumes
-    │   manage.sh
-    │   caddy.json
-    │
-    └───linkace
-    │   │   docker-compose.yml
-    │   │   .env
-    │   └───data
-    │
-    └───other_app
-        └─── docker-compose.yml
-
-```
-
-### Backups
-When a backup completes, the archive is placed in the `backup` folder named `<service><date>.tar.bz2`. The date is deliberately day-resolution so a daily/weekly/monthly cron run produces one archive per period. If you back up more than once in a day, the extra runs get a `_HHMMSS` suffix instead of overwriting the first. Set `BACKUP_KEEP=N` to prune automatically to the newest N archives per app after each run.
-
-```
-userfolder
-│
-└───docker_volumes
-    │   manage.sh
-    │   caddy.json
-    │
-    └───linkace
-    │   │   docker-compose.yml
-    │   │   .env
-    │   └───data
-    │
-    └───backup
-        └─── linkace2022-07-12.tar.bz2
-
-```
-I have another system that connects and executes an [rsync](https://download.samba.org/pub/rsync/rsync.1) to copy files to another location. This is outside the scope of the script however.
-
-
-## Things learnt
-### Backups
-#### Troubleshooting
-- If you'd like to see what's going on with your backups, you can change the `tar` command to `tar -cvjf` adding a v for verbose output to see what files it stops on
-- Running as a local user prompted permission issues when trying to tar the files that were created with root. This led to an early exit of the script.
-- Folder names identified under Apps can have a dot e.g `.n8n` at the front or special characters `uptime-kuma` as long as each entry is separated by a space e.g. `Apps=".n8n uptime-kuma linkace"`.
-- If an app's compose file sits one folder deeper (e.g. `myapp/src/docker-compose.yml`), the script follows it automatically as long as there's only one such folder (issue [#6](https://github.com/AdamXweb/DockerDance/issues/6)).
-- Non executable scripts may need permissions updated with `chmod +x ./docker_volumes/manage.sh` to ensure permissions are executable
-- backups may fail if you run out of space / if this is run on a cron to a local folder.
-- the backup folder is created automatically if it doesn't exist yet.
-
-## Things to improve
-- Ability to define the backup target as a remote server or path with more storage
-- A `status` / dashboard view showing every app's state at a glance
-- Health-aware start (wait until containers report healthy before moving on)
-
-See the [CHANGELOG](CHANGELOG.md) for what's landed recently.
-
-### Cron
-The script gives plain, un-coloured output and needs no terminal when run non-interactively, so it drops straight into cron. For example, back up every discovered app nightly at 3am and log it:
-
-`0 3 * * * cd /home/systemadmin/docker_volumes && ./manage.sh backup >> /var/log/dockerdance.log 2>&1`
-
-Set `NOTIFY_WEBHOOK` (easiest in `manage.conf`) to get a Slack/Discord ping when a scheduled run finishes or fails. A lock stops a cron run from overlapping a manual one on the same folder, so you won't get two `stop`/`start` cycles fighting each other.
-
-### Adding script as an alias
-Depending on your system, you could use something like the below to add the script to your path to just type `appmanage` or whatever command you'd like to nickname it to.
-
-`echo "alias appmanage='$HOME/docker_volumes/manage.sh'" >> ~/.bashrc`
-
-### Tab completion
-A bash completion is included in [contrib/dockerdance-completion.bash](contrib/dockerdance-completion.bash). Source it from your shell startup, pointing at wherever you put the file:
-
-`echo "source /path/to/DockerDance/contrib/dockerdance-completion.bash" >> ~/.bashrc`
-
-It completes the commands first, then app folder names.
-
-### example folder
-The repo ships an `example` folder with a tiny alpine compose file. Because the default `Apps="auto"` discovers any folder containing a compose file, a fresh clone treats `example` as an app — handy for a first `./manage.sh start` to confirm everything works (it runs detached with `-d`, so nothing prints; `docker compose up` in the folder shows the test message). Delete the folder once you've added your own apps. If you instead pin `Apps="example"` explicitly, the script refuses to run until you change it.
-
-## License
-
-Docker Dance is released under the MIT license.
+Released under the MIT licence. See [LICENSE](LICENSE).

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -1,0 +1,222 @@
+# Command reference
+
+Run everything from inside your `docker_volumes` folder. `./manage.sh help` prints
+the same list from the script itself, and `./manage.sh --version` prints the
+script version.
+
+Every command runs against all the apps in the `Apps` setting by default. To
+target specific apps, add their folder names after the command, e.g.
+`./manage.sh restart linkace` or `./manage.sh update linkace uptime-kuma`.
+Apps are processed in the order `Apps` lists them; with `Apps="auto"` the
+discovered folders run alphabetically.
+
+## Options
+
+These work with any command, before or after it:
+
+- `--dry-run` — print exactly what would happen (which apps get pulled, stopped,
+  backed up, started) without touching anything.
+- `-y` / `--yes` — skip confirmation prompts, so `update` and `restore` can run
+  unattended.
+- `--stopped=keep|start|skip` — what `update` and `backup` do with apps that are
+  already stopped. See [Keeping apps as you found them](#keeping-apps-as-you-found-them).
+- `--prune` — remove dangling images after an update.
+- `--backup-first` — archive each app before it moves to its new image (`update`).
+- `--no-color` — turn off coloured output, as does setting `NO_COLOR`.
+
+## Interactive menu
+
+`./manage.sh`
+
+Running the script with no arguments on a terminal opens a menu: pick a command,
+then pick the app(s).
+
+- **With [fzf](https://github.com/junegunn/fzf)** the menu is navigable with the
+  arrow keys and type-to-filter. On the command list, `Enter` selects and `Esc`
+  quits. On the app list, `TAB` multi-selects (with a live container-status
+  preview pane), `Enter` confirms and `Esc` goes back to the command list.
+- **Without fzf** a numbered menu is shown — type the number *or* the command
+  name; on the app list enter a space/comma-separated list like `1 3` (or `0`
+  for all), and `b` goes back.
+
+No extra dependencies are required either way. Cron and piped usage are
+unaffected: without a terminal the script prints usage instead of waiting for
+input. Colours and spinners appear only on capable terminals and respect
+[`NO_COLOR`](https://no-color.org). Only one state-changing run is allowed at a
+time per folder — a lock directory keeps a cron backup from overlapping a manual
+update, and a lock whose recorded process has exited is cleared automatically.
+
+## start
+
+`./manage.sh start`
+
+Starts each app with `docker compose up -d`, then waits for it to come up (see
+[Health](#health)).
+
+## stop
+
+`./manage.sh stop`
+
+Stops each app gracefully with `docker compose stop`, giving databases time to
+finish writing before shutdown. `STOP_TIMEOUT` (default 30s) is how long docker
+waits before forcing it.
+
+## restart
+
+`./manage.sh restart`
+
+Stops the apps, then starts them again.
+
+## update
+
+`./manage.sh update`
+
+Pulls the latest images for all target apps in parallel (keeping
+`PARALLEL_PULLS` downloads in flight), then stops and recreates each container
+on the new image — so downtime is the stop/start window, not the download. The
+pull phase names the apps it is downloading and counts them off, printing a line
+per app as it lands.
+
+Apps that are already stopped stay stopped; their image is still pulled, so they
+come up current next time (see [Keeping apps as you found them](#keeping-apps-as-you-found-them)).
+On a terminal it asks for confirmation first (skip with `-y`). An app whose pull
+fails is left running on its current image and reported. Add `--backup-first` to
+archive every app on the way through — that flow already restarts each app on
+its freshly pulled image — and `--prune` to reclaim the old images afterwards.
+
+## backup
+
+`./manage.sh backup`
+
+An all-in-one, per app: it pulls the latest images while the app is still
+running, stops it gracefully, tars its folder into the `backup` folder, then
+starts it back up on the new images. Archives are written `chmod 600` (they
+contain your `.env` secrets) and store paths relative to `docker_volumes`, so a
+`restore` is portable. A second backup on the same day gets a `_HHMMSS` suffix
+rather than overwriting the first. Set `BACKUP_KEEP=N` to keep only the newest N
+archives per app. A backup whose archive fails still starts the app back up
+rather than leaving it stopped.
+
+## restore
+
+```
+./manage.sh restore linkace
+./manage.sh restore linkace 2026-08-01
+```
+
+Puts a backup archive for the app back in place — the newest by default, or the
+one for the date you name: stops the app, moves the current folder aside to
+`<app>.pre-restore.<timestamp>` (nothing is deleted), extracts the archive, and
+starts the app again. Asks for confirmation, which needs a terminal or `-y`.
+Older v0.1.0-era archives (absolute paths) are detected and restored too.
+
+Archives are treated as untrusted: extraction happens in an isolated staging
+area, any path-traversal (`..`) member is refused, and only the app's own folder
+is promoted, so a tampered archive cannot write elsewhere on disk.
+
+## status
+
+`./manage.sh status`
+
+A dashboard with one line per app: a coloured running/stopped dot, container
+state (`up` / `N/M up` / `stopped`), the image in use, and health. Read-only.
+
+## Health
+
+After starting an app — via `start`, `restart`, `update`, `backup` or `restore` —
+the script waits for its containers to come up rather than assuming they will.
+Containers with a healthcheck must report `healthy`; those without just need to
+be running. The result line becomes e.g. `linkace started, healthy`, or a
+warning if a container is unhealthy or still starting after `HEALTH_TIMEOUT`
+(default 60s; set `0` to skip the wait). The wait is best-effort and never fails
+the run.
+
+## Keeping apps as you found them
+
+`update` and `backup` check which apps are actually running before they touch
+anything, and put each one back the way they found it. An app you deliberately
+stopped is **not** started as a side effect of updating — its new image is still
+pulled, so it comes up current the next time you start it.
+
+You see the split up front, and on a terminal a single prompt settles the rest:
+
+```
+  ● 5 running: authelia, gitea, immich, jellyfin, nextcloud
+  ○ 3 stopped: audiobookshelf, larapaper, vaultwarden
+Update 5 running app(s). The other 3 are stopped - what should happen to them?
+  1) leave them stopped, but pull so they're current next start (recommended)
+  2) start them too, so everything ends up running
+  3) skip them entirely - no pull, no changes
+  n) cancel
+Choose [1]:
+```
+
+For cron and scripts, `--stopped=keep|start|skip` (or `STOPPED_POLICY` in
+`manage.conf`) picks the same three answers without prompting — as does `-y`,
+which takes the default. `--stopped=start` is the older behaviour, where
+everything ends up running.
+
+`backup` follows the same rule: a stopped app is archived where it lies, without
+being started to do it. `stop`, `start` and `restart` are unaffected — those are
+explicit instructions rather than a sweep, so `restart` on a stopped app still
+starts it.
+
+## When something fails
+
+One bad app does not end the run. If an app's containers will not start, its
+folder is missing, or its archive cannot be written, that app is reported and the
+run carries on through the rest. The failure is printed where it happens — the
+command's own output, plus a `[hint]` line when the cause is a recognisable one
+(an image with no build for your architecture, a bind-mount path docker cannot
+reach, a port already taken, an image or tag that does not exist, a full disk, a
+*folder* named `compose.yaml` shadowing the real compose file).
+
+Every run then closes with a per-app table and a tally:
+
+```
+  ● authelia                 updated         4s
+  ○ audiobookshelf           failed         12s
+  ○ larapaper                skipped         0s
+[warn] - Updated 27 of 30 apps in 3m 4s - 1 failed, 2 skipped
+  failed:  audiobookshelf, vaultwarden
+  skipped: larapaper, pinchflat-X
+```
+
+`skipped` means the app was left untouched (its image pull failed, so it stays
+on the image it has); `failed` means the command was attempted and did not work;
+`unhealthy` means the app started on its new image but never reported healthy
+within `HEALTH_TIMEOUT`. The script exits non-zero when any of those buckets is
+non-empty, so a cron job or wrapper can tell without parsing the output.
+
+## Smaller commands
+
+`./manage.sh logs` — recent logs for each app. When a single app is targeted
+(e.g. `./manage.sh logs linkace`) the log is followed live with `-f`; Ctrl-C
+stops.
+
+`./manage.sh version` — the image versions each app is using
+(`docker compose images`).
+
+`./manage.sh running` — the running containers (`docker ps`).
+
+`./manage.sh prune` — remove dangling images left behind by updates.
+
+`./manage.sh doctor` — a read-only environment check: docker daemon
+reachability, the compose flavour in use, whether `curl`/`wget`/`fzf` are
+present, the package manager `system-update` would use, `tar` safety, whether
+`DOCKER_VOLUMES` is writable, `manage.conf`, a stale lock, the effective
+settings and the discovered app list. Handy for first-run setup and bug reports.
+
+`./manage.sh system-update` — updates the host OS packages with whatever package
+manager the system has: `apt-get` (Debian/Ubuntu), `dnf` (Fedora/RHEL), `yum`,
+`pacman` (Arch), `zypper` (openSUSE), `apk` (Alpine) or `brew` (macOS), detected
+in that order. Distro managers need root and it tells you to `sudo`; Homebrew
+refuses root and must run as your normal user. `./manage.sh apt` still works as
+an alias.
+
+`./manage.sh update-self` — updates the script itself to the latest
+[GitHub release](https://github.com/AdamXweb/DockerDance/releases): downloads
+`manage.sh` at the release tag, syntax-checks it, verifies the published
+`manage.sh.sha256` when the release has one (v0.4.0 onwards) and the host can
+hash, carries your `Apps`/`USERNAME` settings over, and swaps it in place. Use
+`manage.conf` for configuration and there is nothing to carry over.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,154 @@
+# Configuration and layout
+
+## Where settings live
+
+Every setting below can be edited at the top of `manage.sh`, exported in the
+environment, or — preferably — put in a `manage.conf` file next to `manage.sh`.
+`manage.conf` is sourced at startup, so it is plain shell (`VAR="value"`, one per
+line, `#` starts a comment), and settings there survive `./manage.sh update-self`.
+
+```
+cp manage.conf.example manage.conf
+```
+
+[`docker_volumes/manage.conf.example`](../docker_volumes/manage.conf.example)
+ships every option commented out with its default.
+
+## Settings
+
+`Apps` (default `auto`) — with `auto`, the script discovers every folder within
+`docker_volumes` that contains a compose file (`docker-compose.yml`/`.yaml` or
+`compose.yml`/`.yaml`, or one folder deeper) and manages all of them in
+alphabetical order. The `backup` folder and `*.pre-restore.*` folders are
+skipped. To pin the set and the order instead, list the folders explicitly, e.g.
+`Apps="linkace .n8n dashy"`.
+
+`USERNAME` (default `systemadmin`) — the user whose home holds `docker_volumes`.
+It is only used to build the default `DOCKER_VOLUMES` path. If you are stuck,
+`pwd` gives the path you are in and `whoami` the user name.
+
+`DOCKER_VOLUMES` (default `/home/$USERNAME/docker_volumes/`) — absolute path to
+the folder, trailing slash included. It can be set from the environment without
+editing anything, which is handy on macOS:
+`DOCKER_VOLUMES="/Users/UserName/docker_volumes/" ./manage.sh start`
+
+`STOPPED_POLICY` (default `keep`) — what `update`/`backup` do with apps that are
+already stopped: `keep` leaves them stopped with their new image ready, `start`
+brings them up too, `skip` leaves them entirely alone. Same values as
+`--stopped=`.
+
+`STOP_TIMEOUT` (default `30`) — seconds to wait for containers to shut down
+gracefully before docker gives up. Raise it for databases that take a while to
+flush.
+
+`HEALTH_TIMEOUT` (default `60`) — after starting an app, seconds to wait for its
+containers to become healthy (or just running, if they have no healthcheck)
+before moving on. Set `0` to skip the wait entirely.
+
+`PARALLEL_PULLS` (default `3`) — how many image pulls `update`/`backup` keep in
+flight at once; as each one finishes the next app starts straight away. Set `1`
+for one-at-a-time pulls.
+
+`BACKUP_KEEP` (unset by default) — when set to a number, only that many
+most-recent backup archives are kept per app; older ones are pruned after each
+backup.
+
+`PRUNE_AFTER_UPDATE` (unset by default) — set `1` to remove dangling images
+after every update, the same as passing `--prune`.
+
+`NOTIFY_WEBHOOK` (unset by default) — a webhook URL that gets a message when an
+update, backup or restore completes or fails. The payload carries both a Slack
+`text` and a Discord `content` field, so an incoming-webhook URL from either
+works as-is. Handy for cron runs. See issue
+[#3](https://github.com/AdamXweb/DockerDance/issues/3).
+
+## Folder structure
+
+The default path is `~/docker_volumes`. Each service has its own folder with its
+own compose file. Running [LinkAce](https://github.com/Kovah/LinkAce), for
+example, with a volume mount to the `data` folder below:
+
+```
+userfolder
+│
+└───docker_volumes
+    │   manage.sh
+    │   manage.conf
+    │
+    └───linkace
+    │   │   docker-compose.yml
+    │   │   .env
+    │   └───data
+    │
+    └───other_app
+        └─── docker-compose.yml
+```
+
+Backup archives land in the `backup` folder, which is created if it does not
+exist, named `<service>_<date>.tar.bz2`. The date is deliberately
+day-resolution, so a daily/weekly/monthly cron run produces one archive per
+period; more than one backup in a day gets a `_HHMMSS` suffix.
+
+```
+    └───backup
+        └─── linkace_2026-08-01.tar.bz2
+```
+
+Copying archives off-box is outside the script's scope — I use a separate system
+that [rsync](https://download.samba.org/pub/rsync/rsync.1)s them elsewhere.
+
+## Permissions and secrets
+
+The script is meant to run on a Unix-like system as a user with privileges to
+modify the app files — root, or a user whose group can read the volume data — so
+that backing up database files created by root does not fail with a permission
+error.
+
+App folders usually contain a `.env` with credentials, so the backup archives do
+too. They are written `chmod 600` (owner-only), and the `backup` folder inherits
+the permissions of the `docker_volumes` tree. `restore` never deletes your
+current data: it moves it aside to `<app>.pre-restore.<timestamp>` and asks for
+confirmation before extracting. If you sync backups off-box, treat that copy as
+sensitive too.
+
+## Cron
+
+The script gives plain, un-coloured output and needs no terminal when run
+non-interactively, so it drops straight into cron. To back up every discovered
+app nightly at 3am and log it:
+
+```
+0 3 * * * cd /home/systemadmin/docker_volumes && ./manage.sh backup >> /var/log/dockerdance.log 2>&1
+```
+
+Set `NOTIFY_WEBHOOK` to get a Slack/Discord ping when a scheduled run finishes or
+fails. The lock stops a cron run from overlapping a manual one on the same
+folder, so you will not get two `stop`/`start` cycles fighting each other.
+
+## An alias
+
+To reach the script from anywhere as `appmanage`, or whatever you would rather
+call it:
+
+```
+echo "alias appmanage='$HOME/docker_volumes/manage.sh'" >> ~/.bashrc
+```
+
+## Tab completion
+
+Completions for bash, zsh and fish live in [contrib/](../contrib). They complete
+the commands first, then app folder names. For bash:
+
+```
+echo "source /path/to/DockerDance/contrib/dockerdance-completion.bash" >> ~/.bashrc
+```
+
+## The example folder
+
+The repo ships an [`example`](../docker_volumes/example) folder with a tiny
+alpine compose file. Because the default `Apps="auto"` discovers any folder
+containing a compose file, a fresh clone treats `example` as an app — handy for a
+first `./manage.sh start` to confirm everything works. It runs detached with
+`-d`, so nothing prints; `docker compose up` in the folder shows the test
+message. Delete the folder once you have added your own apps. If you instead pin
+`Apps="example"` explicitly, the script refuses to run until you change it.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,41 @@
+# Troubleshooting
+
+Start with `./manage.sh doctor` — it is read-only and reports the docker daemon,
+the compose flavour in use, which of `curl`/`wget`/`fzf` are present, the
+package manager `system-update` would use, `tar` safety, whether
+`DOCKER_VOLUMES` is writable, whether a `manage.conf` was read, a stale lock,
+the effective settings and the discovered app list. Its output is also the most
+useful thing to paste into a bug report.
+
+## Notes collected along the way
+
+- Running as a local user caused permission errors when tarring files created by
+  root, which ended the run early. Run as root, or as a user whose group can
+  read the volume data.
+- Folder names in `Apps` can start with a dot (`.n8n`) or contain special
+  characters (`uptime-kuma`), as long as entries are separated by spaces:
+  `Apps=".n8n uptime-kuma linkace"`.
+- If an app's compose file sits one folder deeper (e.g.
+  `myapp/src/docker-compose.yml`), the script follows it automatically as long
+  as there is only one such folder (issue
+  [#6](https://github.com/AdamXweb/DockerDance/issues/6)).
+- A non-executable script needs `chmod +x ./docker_volumes/manage.sh`.
+- Backups can fail if you run out of space — worth watching if a cron job writes
+  archives to a local folder.
+- The `backup` folder is created automatically if it is not there yet.
+- To see what `tar` is doing during a backup, change the `tar` command in
+  `manage.sh` to `tar -cvjf` — the `v` makes it print each file, so you can see
+  where it stops.
+
+## A lock is in the way
+
+Only one state-changing run happens at a time per `docker_volumes` folder, using
+a `.dockerdance.lock` directory. A lock whose recorded process has exited is
+cleared automatically on the next run. A lock with no readable pid is not
+cleared for you — remove it by hand once you are sure no run is active.
+
+## Ideas not yet built
+
+- Defining the backup target as a remote server or path with more storage.
+
+See the [CHANGELOG](../CHANGELOG.md) for what has landed recently.


### PR DESCRIPTION
Brings the README into line with the portfolio-wide standard: hero, badge row, disclosure block, then overview / What it does / Get it / Contributing / Licence.

## Size

README.md: **21,306 -> 6,183 bytes**. Nothing was deleted — the reference material moved:

| New file | What moved into it |
| :-- | :-- |
| `docs/commands.md` | Full command reference, global options, interactive menu, Health, "Keeping apps as you found them", "When something fails", the minor commands |
| `docs/configuration.md` | All settings and their defaults, `manage.conf`, folder/backup structure, permissions and secrets note, cron, alias, tab completion, the `example` folder |
| `docs/troubleshooting.md` | The "Things learnt" notes, the verbose-`tar` tip, lock handling, remaining ideas |
| `CONTRIBUTING.md` | Prerequisites, `tests/run-tests.sh`, ShellCheck/`dash` targets, what CI checks, the release process |

## Facts corrected

- **"from v0.4.1 each release carries `manage.sh` and a `manage.sh.sha256`"** — wrong version. Assets have been attached since **v0.4.0** (verified: `gh release view v0.4.0` lists both, `v0.3.0` lists none), and `update_self` in `manage.sh` says "Releases from v0.4.0 publish a checksum". Now reads v0.4.0.
- **"Things to improve"** listed a `status`/dashboard view and health-aware start as not-yet-built. Both shipped — `./manage.sh status` and the `HEALTH_TIMEOUT` wait are in `manage.sh` and documented in the old README a few sections above. Removed from the list.
- **`caddy.json` in the folder-structure diagrams** — not part of the repo or the script's behaviour. Replaced with `manage.conf`, which is real.
- **Backup archive naming** was shown as `linkace2022-07-12.tar.bz2`; since v0.4.0 archives use a separator (`linkace_2026-08-01.tar.bz2`) so that one app's name being another's prefix cannot mismatch. Diagram updated.
- **`Commands` list was missing `running` and `prune`**, both of which the script's own `usage()` documents. Added to `docs/commands.md`.
- The `./manage.sh restore <app> <date>` form was shown without explanation; now described.

## Links and badges

Every link in all five files was checked. No dead links were found in the old README — all external URLs (docker docs, fzf, no-color.org, issues #3 and #6, LinkAce, rsync man page, the two `user-images.githubusercontent.com` assets) return 200 and were kept. New relative links were checked with `test -e`; new external links (shellcheck.net, casey/just, keepachangelog.com) return 200.

Badge row, all four verified as resolving to real values:

- **Project status** — endpoint badge from the `AdamXweb/.github` hub; `badges/DockerDance.json` returns 200 and renders `Active`. The anchor is `STATUS.md#dockerdance`, matching the lowercased `### DockerDance` heading in that file.
- **Release** — `v0.4.0` is published, non-draft, non-prerelease.
- **Lint** — `.github/workflows/shellcheck.yml` triggers on pushes to `main` and has 10 completed runs on `main`; badge pinned with `?branch=main`.
- **Licence** — `LICENSE` (MIT) exists.

## Note on provenance

This PR comes from a temporary fork, `adamXbot/tmp-DockerDance`, which will be deleted after the merge. No source, workflow or config file is touched — the diff is `README.md` plus four new documentation files.